### PR TITLE
phase-2a: useSupabaseChannel — shared realtime subscription hook

### DIFF
--- a/apps/hrms-web/src/hooks/useSupabaseChannel.ts
+++ b/apps/hrms-web/src/hooks/useSupabaseChannel.ts
@@ -1,0 +1,102 @@
+import { useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+// One hook to replace the inline supabase.channel(...).on(...).subscribe()
+// boilerplate currently duplicated in ApprovalInbox, Notifications,
+// SalesContext, and several Auto Aging surfaces. Reduces three concerns to
+// one: name the channel, declare the subscriptions, handle the events.
+//
+// Each subscription is a postgres_changes binding. The handler is called
+// for every event that matches its (event, schema, table, filter). The
+// subscription auto-cleans on unmount.
+//
+//   useSupabaseChannel({
+//     name: `approval-inbox:${companyId}`,
+//     enabled: !!companyId,
+//     subscriptions: [
+//       { event: '*', table: 'leave_requests', filter: `company_id=eq.${companyId}` },
+//       { event: '*', table: 'payroll_runs',   filter: `company_id=eq.${companyId}` },
+//       { event: '*', table: 'appraisals',     filter: `company_id=eq.${companyId}` },
+//     ],
+//     onChange: () => queryClient.invalidateQueries({ queryKey }),
+//   });
+//
+// Per-subscription onChange is also supported when an INSERT needs a
+// different optimistic update than an UPDATE (see Notifications.tsx).
+
+export type RealtimeEvent = 'INSERT' | 'UPDATE' | 'DELETE' | '*';
+
+export interface ChannelSubscription<TRow = Record<string, unknown>> {
+  event?: RealtimeEvent;
+  schema?: string;
+  table: string;
+  filter?: string;
+  // Per-subscription handler. Overrides the channel-wide onChange.
+  onChange?: (payload: SupabasePayload<TRow>) => void;
+}
+
+export interface SupabasePayload<TRow = Record<string, unknown>> {
+  schema: string;
+  table: string;
+  eventType: 'INSERT' | 'UPDATE' | 'DELETE';
+  new: TRow;
+  old: TRow;
+}
+
+export interface UseSupabaseChannelOptions<TRow = Record<string, unknown>> {
+  name: string;
+  enabled?: boolean;
+  subscriptions: ChannelSubscription<TRow>[];
+  // Channel-wide handler. Called for every subscription that does not
+  // declare its own onChange.
+  onChange?: (payload: SupabasePayload<TRow>) => void;
+}
+
+export function useSupabaseChannel<TRow = Record<string, unknown>>(
+  options: UseSupabaseChannelOptions<TRow>,
+): void {
+  const { name, enabled = true, subscriptions, onChange } = options;
+
+  // The subscriptions array is rebuilt on every render. We re-subscribe
+  // when its serialized shape changes so the effect dependency list stays
+  // primitive and the channel doesn't churn on every render.
+  const subscriptionKey = JSON.stringify(
+    subscriptions.map((s) => ({
+      event: s.event ?? '*',
+      schema: s.schema ?? 'public',
+      table: s.table,
+      filter: s.filter ?? null,
+    })),
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let channel = supabase.channel(name);
+    for (const sub of subscriptions) {
+      const handler = sub.onChange ?? onChange;
+      if (!handler) continue;
+      // The supabase-js typings narrow the second arg by event literal,
+      // so we cast through unknown to keep the call site one-shot.
+      channel = channel.on(
+        // deno-lint-ignore no-explicit-any
+        'postgres_changes' as unknown as any,
+        {
+          event: sub.event ?? '*',
+          schema: sub.schema ?? 'public',
+          table: sub.table,
+          ...(sub.filter ? { filter: sub.filter } : {}),
+        },
+        (payload: unknown) => handler(payload as SupabasePayload<TRow>),
+      );
+    }
+    channel.subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+    // subscriptionKey captures the structural shape of `subscriptions`;
+    // including the array directly would re-subscribe on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name, enabled, subscriptionKey, onChange]);
+}

--- a/apps/hrms-web/src/pages/hrms/ApprovalInbox.tsx
+++ b/apps/hrms-web/src/pages/hrms/ApprovalInbox.tsx
@@ -21,7 +21,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
 import { useHrmsAccess } from '@/hooks/useHrmsAccess';
 import { approvalInboxQueryKey, useApprovalInboxItems } from '@/hooks/useApprovalInboxItems';
-import { supabase } from '@/integrations/supabase/client';
+import { useSupabaseChannel } from '@/hooks/useSupabaseChannel';
 import {
   reviewAppraisalActivation,
   reviewLeaveRequest,
@@ -88,32 +88,20 @@ export default function ApprovalInbox() {
   }, [inboxErrors, toast]);
 
   // Real-time: reload inbox when any approval-related table changes for this company.
-  useEffect(() => {
-    if (!user?.companyId) return;
-
-    const channel = supabase
-      .channel(`approval-inbox:${user.companyId}`)
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'leave_requests', filter: `company_id=eq.${user.companyId}` },
-        () => void queryClient.invalidateQueries({ queryKey: approvalInboxQueryKey(user.companyId) }),
-      )
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'payroll_runs', filter: `company_id=eq.${user.companyId}` },
-        () => void queryClient.invalidateQueries({ queryKey: approvalInboxQueryKey(user.companyId) }),
-      )
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'appraisals', filter: `company_id=eq.${user.companyId}` },
-        () => void queryClient.invalidateQueries({ queryKey: approvalInboxQueryKey(user.companyId) }),
-      )
-      .subscribe();
-
-    return () => {
-      void supabase.removeChannel(channel);
-    };
-  }, [user?.companyId, queryClient]);
+  useSupabaseChannel({
+    name: `approval-inbox:${user?.companyId ?? 'anon'}`,
+    enabled: !!user?.companyId,
+    subscriptions: [
+      { event: '*', table: 'leave_requests', filter: `company_id=eq.${user?.companyId ?? ''}` },
+      { event: '*', table: 'payroll_runs',   filter: `company_id=eq.${user?.companyId ?? ''}` },
+      { event: '*', table: 'appraisals',     filter: `company_id=eq.${user?.companyId ?? ''}` },
+    ],
+    onChange: () => {
+      if (user?.companyId) {
+        void queryClient.invalidateQueries({ queryKey: approvalInboxQueryKey(user.companyId) });
+      }
+    },
+  });
 
   const filteredItems = useMemo(() => {
     const filtered = filterApprovalInboxItems(items, filter);

--- a/src/hooks/useSupabaseChannel.ts
+++ b/src/hooks/useSupabaseChannel.ts
@@ -1,0 +1,102 @@
+import { useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+// One hook to replace the inline supabase.channel(...).on(...).subscribe()
+// boilerplate currently duplicated in ApprovalInbox, Notifications,
+// SalesContext, and several Auto Aging surfaces. Reduces three concerns to
+// one: name the channel, declare the subscriptions, handle the events.
+//
+// Each subscription is a postgres_changes binding. The handler is called
+// for every event that matches its (event, schema, table, filter). The
+// subscription auto-cleans on unmount.
+//
+//   useSupabaseChannel({
+//     name: `approval-inbox:${companyId}`,
+//     enabled: !!companyId,
+//     subscriptions: [
+//       { event: '*', table: 'leave_requests', filter: `company_id=eq.${companyId}` },
+//       { event: '*', table: 'payroll_runs',   filter: `company_id=eq.${companyId}` },
+//       { event: '*', table: 'appraisals',     filter: `company_id=eq.${companyId}` },
+//     ],
+//     onChange: () => queryClient.invalidateQueries({ queryKey }),
+//   });
+//
+// Per-subscription onChange is also supported when an INSERT needs a
+// different optimistic update than an UPDATE (see Notifications.tsx).
+
+export type RealtimeEvent = 'INSERT' | 'UPDATE' | 'DELETE' | '*';
+
+export interface ChannelSubscription<TRow = Record<string, unknown>> {
+  event?: RealtimeEvent;
+  schema?: string;
+  table: string;
+  filter?: string;
+  // Per-subscription handler. Overrides the channel-wide onChange.
+  onChange?: (payload: SupabasePayload<TRow>) => void;
+}
+
+export interface SupabasePayload<TRow = Record<string, unknown>> {
+  schema: string;
+  table: string;
+  eventType: 'INSERT' | 'UPDATE' | 'DELETE';
+  new: TRow;
+  old: TRow;
+}
+
+export interface UseSupabaseChannelOptions<TRow = Record<string, unknown>> {
+  name: string;
+  enabled?: boolean;
+  subscriptions: ChannelSubscription<TRow>[];
+  // Channel-wide handler. Called for every subscription that does not
+  // declare its own onChange.
+  onChange?: (payload: SupabasePayload<TRow>) => void;
+}
+
+export function useSupabaseChannel<TRow = Record<string, unknown>>(
+  options: UseSupabaseChannelOptions<TRow>,
+): void {
+  const { name, enabled = true, subscriptions, onChange } = options;
+
+  // The subscriptions array is rebuilt on every render. We re-subscribe
+  // when its serialized shape changes so the effect dependency list stays
+  // primitive and the channel doesn't churn on every render.
+  const subscriptionKey = JSON.stringify(
+    subscriptions.map((s) => ({
+      event: s.event ?? '*',
+      schema: s.schema ?? 'public',
+      table: s.table,
+      filter: s.filter ?? null,
+    })),
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let channel = supabase.channel(name);
+    for (const sub of subscriptions) {
+      const handler = sub.onChange ?? onChange;
+      if (!handler) continue;
+      // The supabase-js typings narrow the second arg by event literal,
+      // so we cast through unknown to keep the call site one-shot.
+      channel = channel.on(
+        // deno-lint-ignore no-explicit-any
+        'postgres_changes' as unknown as any,
+        {
+          event: sub.event ?? '*',
+          schema: sub.schema ?? 'public',
+          table: sub.table,
+          ...(sub.filter ? { filter: sub.filter } : {}),
+        },
+        (payload: unknown) => handler(payload as SupabasePayload<TRow>),
+      );
+    }
+    channel.subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+    // subscriptionKey captures the structural shape of `subscriptions`;
+    // including the array directly would re-subscribe on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name, enabled, subscriptionKey, onChange]);
+}

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { PageHeader } from '@/components/shared/PageHeader';
 import { StatusBadge } from '@/components/shared/StatusBadge';
 import { useAuth } from '@/contexts/AuthContext';
 import { getNotifications, markAsRead, markAllAsRead, NotificationRow } from '@/services/notificationService';
-import { supabase } from '@/integrations/supabase/client';
+import { useSupabaseChannel, type SupabasePayload } from '@/hooks/useSupabaseChannel';
 import { STALE } from '@/lib/queryClient';
 import { Button } from '@/components/ui/button';
 import { CheckCheck, Bell } from 'lucide-react';
@@ -25,32 +25,32 @@ export default function Notifications() {
   });
 
   // Realtime: prepend new notifications live without a full refetch.
-  useEffect(() => {
-    if (!user) return;
-    const channel = supabase
-      .channel(`realtime:notifications:${user.id}`)
-      .on(
-        'postgres_changes',
-        { event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${user.id}` },
-        (payload) => {
+  useSupabaseChannel<NotificationRow>({
+    name: `realtime:notifications:${user?.id ?? 'anon'}`,
+    enabled: !!user?.id,
+    subscriptions: [
+      {
+        event: 'INSERT',
+        table: 'notifications',
+        filter: `user_id=eq.${user?.id ?? ''}`,
+        onChange: (payload: SupabasePayload<NotificationRow>) => {
           queryClient.setQueryData<NotificationRow[]>(notifKey, prev =>
-            [payload.new as NotificationRow, ...(prev ?? [])]
+            [payload.new, ...(prev ?? [])]
           );
-        }
-      )
-      .on(
-        'postgres_changes',
-        { event: 'UPDATE', schema: 'public', table: 'notifications', filter: `user_id=eq.${user.id}` },
-        (payload) => {
+        },
+      },
+      {
+        event: 'UPDATE',
+        table: 'notifications',
+        filter: `user_id=eq.${user?.id ?? ''}`,
+        onChange: (payload: SupabasePayload<NotificationRow>) => {
           queryClient.setQueryData<NotificationRow[]>(notifKey, prev =>
-            (prev ?? []).map(n => n.id === (payload.new as NotificationRow).id ? payload.new as NotificationRow : n)
+            (prev ?? []).map(n => n.id === payload.new.id ? payload.new : n)
           );
-        }
-      )
-      .subscribe();
-    return () => { supabase.removeChannel(channel); };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.id]);
+        },
+      },
+    ],
+  });
 
   const handleMarkRead = async (id: string) => {
     if (!user?.id) return;


### PR DESCRIPTION
## Phase 2a — Realtime subscription hook

First subtask of Phase 2 (Architecture cleanup) per `PRODUCT_RECONSTRUCTION.md`.

### What

Replace inline `supabase.channel(...).on(...).subscribe()` boilerplate in `ApprovalInbox` (hrms-web) and `Notifications` (main) with a single declarative hook.

```ts
useSupabaseChannel({
  name: `approval-inbox:${companyId}`,
  enabled: !!companyId,
  subscriptions: [
    { event: '*', table: 'leave_requests', filter: `company_id=eq.${companyId}` },
    { event: '*', table: 'payroll_runs',   filter: `company_id=eq.${companyId}` },
    { event: '*', table: 'appraisals',     filter: `company_id=eq.${companyId}` },
  ],
  onChange: () => queryClient.invalidateQueries({ queryKey }),
});
```

Per-subscription `onChange` is also supported so `Notifications` can optimistically prepend on `INSERT` and replace-in-place on `UPDATE` through the same hook (see `src/pages/Notifications.tsx`).

### Why this subtask is small on purpose

The blueprint Phase 2 has 7 items; per request we're shipping one PR per subtask. This is the smallest, lowest-risk one — pure refactor, same realtime behaviour, no schema changes, no UX changes.

Two parallel copies for now (`src/hooks/useSupabaseChannel.ts` + `apps/hrms-web/src/hooks/useSupabaseChannel.ts`). Phase 2b will consolidate the two app shells + duplicated hooks into a `packages/shell` package.

### Test plan
- [x] `tsc --noEmit` clean
- [ ] Manual smoke: open `/notifications`, insert a row via Studio, confirm it prepends without refetch
- [ ] Manual smoke: open hrms-web `/approvals`, submit a leave request from another browser, confirm the inbox auto-refreshes
- [ ] `npm run test -- src/pages/Notifications`  and  `npm run test -- apps/hrms-web/src/pages/hrms/ApprovalInbox` if those test files exist

### Files changed
- `src/hooks/useSupabaseChannel.ts` (new)
- `apps/hrms-web/src/hooks/useSupabaseChannel.ts` (new — copy; 2b will dedupe)
- `src/pages/Notifications.tsx` (refactor)
- `apps/hrms-web/src/pages/hrms/ApprovalInbox.tsx` (refactor)

### Next subtask
Phase 2b — extract `packages/shell` so the two AppShell trees and the two `useSupabaseChannel` copies become one.

---
_Generated by [Claude Code](https://claude.ai/code/session_0126qBxLNiA2u8QRoUKQwqYg)_