### PR TITLE
phase-2b: global_search RPC — one Cmd+K query, RLS-scoped

### DIFF
--- a/scripts/check-rpc-contracts.ts
+++ b/scripts/check-rpc-contracts.ts
@@ -88,6 +88,26 @@ const targets: FunctionTarget[] = [
       },
     ],
   },
+  {
+    functionName: 'public.global_search',
+    checks: [
+      {
+        kind: 'required',
+        pattern: /security\s+invoker/i,
+        message: 'global_search must remain SECURITY INVOKER so RLS does the company / role filtering',
+      },
+      {
+        kind: 'required',
+        pattern: /returns\s+table\s*\([\s\S]*?\bentity_type\s+text\b/i,
+        message: 'global_search must return a row set including an entity_type column the client switches on',
+      },
+      {
+        kind: 'forbidden',
+        pattern: /security\s+definer/i,
+        message: 'global_search must NOT be SECURITY DEFINER — that would bypass per-table RLS and leak rows across companies',
+      },
+    ],
+  },
 ];
 
 for (const target of targets) {

--- a/src/components/layout/app-shell/mainShellConfig.ts
+++ b/src/components/layout/app-shell/mainShellConfig.ts
@@ -43,15 +43,13 @@ import { useLocation } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { useModuleAccess } from '@/contexts/ModuleAccessContext';
 import { useBranding } from '@/contexts/BrandingContext';
-import { useSales } from '@/contexts/SalesContext';
 import { useFocusedMode } from '@/hooks/useFocusedMode';
 import { useRoleSectionMatrix } from '@/hooks/usePermissions';
 import { getDedicatedHrmsWorkspacePath, HRMS_PATHS, isHrmsWorkspacePath } from '@/lib/hrmsWorkspace';
 import { getModuleIdForPath, getModuleIdForSection } from '@/lib/moduleAccess';
 import { STALE } from '@/lib/queryClient';
 import { getNotifications } from '@/services/notificationService';
-import { listProfiles } from '@/services/profileService';
-import { searchVehicles } from '@/services/vehicleService';
+import { globalSearch, type GlobalSearchHit } from '@/services/globalSearchService';
 import type { AppRole } from '@/types';
 import type { AppShellCommandItem, AppShellNavItem, AppShellNavSection, AppShellRouteChromeMatch } from './types';
 
@@ -173,9 +171,23 @@ function resolveNavigationHref(path: string): string {
   return isHrmsWorkspacePath(path) ? getDedicatedHrmsWorkspacePath(path) : path;
 }
 
-function textMatches(query: string, ...values: Array<string | number | null | undefined>): boolean {
-  const normalizedQuery = query.toLowerCase();
-  return values.some((value) => String(value ?? '').toLowerCase().includes(normalizedQuery));
+const HIT_TYPE_META: Record<GlobalSearchHit['entityType'], { section: string; icon: typeof Car }> = {
+  vehicle:     { section: 'Vehicles',     icon: Car },
+  customer:    { section: 'Customers',    icon: Users },
+  sales_order: { section: 'Sales Orders', icon: ShoppingCart },
+  profile:     { section: 'Users',        icon: Shield },
+};
+
+function toCommandItem(hit: GlobalSearchHit): AppShellCommandItem {
+  const meta = HIT_TYPE_META[hit.entityType];
+  return {
+    id: `${hit.entityType}:${hit.entityId}`,
+    label: hit.label,
+    description: hit.description ?? meta.section,
+    section: meta.section,
+    icon: meta.icon,
+    to: hit.href,
+  };
 }
 
 function routeCommandItems(sections: AppShellNavSection[]): AppShellCommandItem[] {
@@ -199,7 +211,6 @@ export function useMainAppShellConfig() {
   const { isFocused } = useFocusedMode();
   const { isModuleActive } = useModuleAccess();
   const { pathname } = useLocation();
-  const { customers, salesOrders } = useSales();
   const rolePermissions = useRoleSectionMatrix();
   const { data: notifications = [] } = useQuery({
     queryKey: ['notifications', user?.id ?? ''],
@@ -256,68 +267,10 @@ export function useMainAppShellConfig() {
     .filter((section) => section.items.length > 0);
   const commandItems = useMemo(() => routeCommandItems(sections), [sections]);
   const unreadCount = notifications.filter((notification) => !notification.read).length;
-  const canSearchUsers = hasRole(['super_admin', 'company_admin']);
   const onCommandSearch = useCallback(async (query: string): Promise<AppShellCommandItem[]> => {
-    const trimmedQuery = query.trim();
-    if (trimmedQuery.length < 2) return [];
-
-    const vehicleResult = await searchVehicles({
-      search: trimmedQuery,
-      limit: 6,
-      sortColumn: 'chassis_no',
-      sortDirection: 'asc',
-    });
-    const vehicleItems: AppShellCommandItem[] = vehicleResult.data.rows.map((vehicle) => ({
-      id: `vehicle:${vehicle.id}`,
-      label: vehicle.chassis_no || 'Vehicle record',
-      description: [vehicle.model, vehicle.branch_code, vehicle.customer_name].filter(Boolean).join(' - '),
-      section: 'Vehicles',
-      icon: Car,
-      to: `/auto-aging/vehicles?search=${encodeURIComponent(vehicle.chassis_no || trimmedQuery)}`,
-    }));
-
-    const customerItems: AppShellCommandItem[] = customers
-      .filter((customer) => textMatches(trimmedQuery, customer.name, customer.phone, customer.email, customer.icNo, customer.nric))
-      .slice(0, 6)
-      .map((customer) => ({
-        id: `customer:${customer.id}`,
-        label: customer.name,
-        description: [customer.phone, customer.email].filter(Boolean).join(' - ') || 'Customer',
-        section: 'Customers',
-        icon: Users,
-        to: `/sales/customers?search=${encodeURIComponent(customer.name)}`,
-      }));
-
-    const orderItems: AppShellCommandItem[] = salesOrders
-      .filter((order) => textMatches(trimmedQuery, order.orderNo, order.customerName, order.model, order.chassisNo, order.vsoNo, order.plateNo))
-      .slice(0, 6)
-      .map((order) => ({
-        id: `sales-order:${order.id}`,
-        label: order.orderNo,
-        description: [order.customerName, order.model].filter(Boolean).join(' - ') || 'Sales order',
-        section: 'Sales Orders',
-        icon: ShoppingCart,
-        to: `/sales/orders?search=${encodeURIComponent(order.orderNo)}`,
-      }));
-
-    let userItems: AppShellCommandItem[] = [];
-    if (canSearchUsers && user?.company_id) {
-      const profileResult = await listProfiles(user.company_id);
-      userItems = profileResult.data
-        .filter((profile) => textMatches(trimmedQuery, profile.name, profile.email, profile.role, profile.status))
-        .slice(0, 6)
-        .map((profile) => ({
-          id: `profile:${profile.id}`,
-          label: profile.name || profile.email,
-          description: [profile.email, profile.role.replace(/_/g, ' ')].filter(Boolean).join(' - '),
-          section: 'Users',
-          icon: Shield,
-          to: `/admin/users?search=${encodeURIComponent(profile.email)}`,
-        }));
-    }
-
-    return [...vehicleItems, ...customerItems, ...orderItems, ...userItems];
-  }, [canSearchUsers, customers, salesOrders, user?.company_id]);
+    const hits = await globalSearch(query, 6);
+    return hits.map(toCommandItem);
+  }, []);
 
   return {
     brand: {

--- a/src/services/globalSearchService.test.ts
+++ b/src/services/globalSearchService.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { globalSearch } from './globalSearchService';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    rpc: vi.fn(),
+  },
+}));
+
+import { supabase } from '@/integrations/supabase/client';
+
+const rpcMock = supabase.rpc as unknown as ReturnType<typeof vi.fn>;
+
+describe('globalSearch', () => {
+  it('returns empty without calling the RPC for queries shorter than 2 chars', async () => {
+    rpcMock.mockReset();
+    expect(await globalSearch('')).toEqual([]);
+    expect(await globalSearch(' ')).toEqual([]);
+    expect(await globalSearch('a')).toEqual([]);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it('maps RPC rows to GlobalSearchHit shape, preserving order', async () => {
+    rpcMock.mockResolvedValueOnce({
+      data: [
+        {
+          entity_type: 'vehicle',
+          entity_id: 'v-1',
+          label: 'CHASSIS-001',
+          description: 'X70 - HQ - John',
+          href: '/auto-aging/vehicles?search=CHASSIS-001',
+          rank_score: 90,
+        },
+        {
+          entity_type: 'customer',
+          entity_id: 'c-1',
+          label: 'John Doe',
+          description: '012-3456 - john@example',
+          href: '/sales/customers?search=John+Doe',
+          rank_score: 50,
+        },
+      ],
+      error: null,
+    });
+
+    const hits = await globalSearch('CHA', 6);
+    expect(rpcMock).toHaveBeenCalledWith('global_search', { p_query: 'CHA', p_limit: 6 });
+    expect(hits).toEqual([
+      {
+        entityType: 'vehicle',
+        entityId: 'v-1',
+        label: 'CHASSIS-001',
+        description: 'X70 - HQ - John',
+        href: '/auto-aging/vehicles?search=CHASSIS-001',
+        rankScore: 90,
+      },
+      {
+        entityType: 'customer',
+        entityId: 'c-1',
+        label: 'John Doe',
+        description: '012-3456 - john@example',
+        href: '/sales/customers?search=John+Doe',
+        rankScore: 50,
+      },
+    ]);
+  });
+
+  it('returns empty on RPC error rather than throwing — Cmd+K must stay snappy', async () => {
+    rpcMock.mockResolvedValueOnce({ data: null, error: new Error('boom') });
+    const hits = await globalSearch('chassis', 6);
+    expect(hits).toEqual([]);
+  });
+
+  it('handles a null data row set as empty', async () => {
+    rpcMock.mockResolvedValueOnce({ data: null, error: null });
+    const hits = await globalSearch('chassis', 6);
+    expect(hits).toEqual([]);
+  });
+
+  it('trims whitespace before evaluating the min-length guard', async () => {
+    rpcMock.mockResolvedValueOnce({ data: [], error: null });
+    await globalSearch('  ab  ', 4);
+    expect(rpcMock).toHaveBeenCalledWith('global_search', { p_query: 'ab', p_limit: 4 });
+  });
+});

--- a/src/services/globalSearchService.ts
+++ b/src/services/globalSearchService.ts
@@ -1,0 +1,84 @@
+import { supabase } from '@/integrations/supabase/client';
+import { loggingService } from './loggingService';
+
+// Wraps the `global_search(p_query, p_limit)` RPC introduced in
+// migration 20260524020000_global_search.sql. Replaces the four parallel
+// queries previously issued by Cmd+K (searchVehicles, customers list
+// filter, sales_orders list filter, listProfiles + client-side filter).
+//
+// RLS does the company / role isolation; this service is a thin typed
+// wrapper. Profiles results are naturally suppressed for non-admins by
+// the existing profiles SELECT policy.
+
+export type GlobalSearchEntityType =
+  | 'vehicle'
+  | 'customer'
+  | 'sales_order'
+  | 'profile';
+
+export interface GlobalSearchHit {
+  entityType: GlobalSearchEntityType;
+  entityId: string;
+  label: string;
+  description: string | null;
+  href: string;
+  rankScore: number;
+}
+
+interface GlobalSearchRow {
+  entity_type: GlobalSearchEntityType;
+  entity_id: string;
+  label: string;
+  description: string | null;
+  href: string;
+  rank_score: number;
+}
+
+type GlobalSearchClient = {
+  rpc: (
+    name: 'global_search',
+    args: { p_query: string; p_limit: number },
+  ) => Promise<{ data: GlobalSearchRow[] | null; error: Error | null }>;
+};
+
+const client = supabase as unknown as GlobalSearchClient;
+
+const MIN_QUERY_LENGTH = 2;
+const DEFAULT_LIMIT_PER_TYPE = 6;
+
+/**
+ * Server-side Cmd+K. Returns up to `limit` matches per entity type, then
+ * orders by rank_score DESC, label ASC. Empty array for queries shorter
+ * than 2 characters (matches the previous client-side guard).
+ */
+export async function globalSearch(
+  query: string,
+  limit: number = DEFAULT_LIMIT_PER_TYPE,
+): Promise<GlobalSearchHit[]> {
+  const term = query.trim();
+  if (term.length < MIN_QUERY_LENGTH) return [];
+
+  const { data, error } = await client.rpc('global_search', {
+    p_query: term,
+    p_limit: limit,
+  });
+
+  if (error) {
+    loggingService.warn(
+      'global_search RPC failed',
+      { error: error.message, query: term },
+      'GlobalSearchService',
+    );
+    return [];
+  }
+  if (!data) return [];
+
+  return data.map((row) => ({
+    entityType: row.entity_type,
+    entityId: row.entity_id,
+    label: row.label,
+    description: row.description,
+    href: row.href,
+    rankScore: row.rank_score,
+  }));
+}

--- a/supabase/migrations/20260524020000_global_search.sql
+++ b/supabase/migrations/20260524020000_global_search.sql
@@ -1,0 +1,193 @@
+-- ─── Global Search RPC ──────────────────────────────────────────────────────
+--
+-- Replaces the four ad-hoc Cmd+K queries in
+-- src/components/layout/app-shell/mainShellConfig.ts (searchVehicles +
+-- local-array filter for customers + local-array filter for sales orders
+-- + listProfiles + client-side filter) with one server-side union.
+--
+-- Why:
+--   • One network round-trip instead of up to four.
+--   • Profiles can be searched without loading the full company roster
+--     into the browser (the admin search currently fetches every profile
+--     and filters client-side).
+--   • RLS is consistent: each subquery runs as the caller, so a non-admin
+--     who could not previously see a row through the page still cannot
+--     see it through the command palette.
+--
+-- Security model:
+--   • SECURITY INVOKER. RLS does the company / role filtering on every
+--     table; no per-call company_id parameter is needed (and would be a
+--     trust anchor we don't want).
+--   • Profiles search is naturally admin-only because the existing
+--     `profiles` SELECT policy already restricts cross-row visibility.
+--
+-- Ranking:
+--   • Exact-prefix matches on the entity's primary identifier (chassis_no,
+--     name, order_no, email) rank above substring matches.
+--   • Score: 100 = exact, 90 = prefix, 50 = contains.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.global_search(
+  p_query text,
+  p_limit integer DEFAULT 6
+) RETURNS TABLE (
+  entity_type  text,
+  entity_id    text,
+  label        text,
+  description  text,
+  href         text,
+  rank_score   integer
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH q AS (
+    SELECT
+      btrim(p_query)                  AS term,
+      lower(btrim(p_query))           AS lterm,
+      LEAST(GREATEST(p_limit, 1), 25) AS lim
+  )
+  SELECT * FROM (
+    -- ── vehicles ──────────────────────────────────────────────────────
+    (
+      SELECT
+        'vehicle'::text                                                AS entity_type,
+        v.id::text                                                     AS entity_id,
+        COALESCE(NULLIF(v.chassis_no, ''), 'Vehicle record')           AS label,
+        NULLIF(
+          concat_ws(' - ',
+            NULLIF(v.model, ''),
+            NULLIF(v.branch_code, ''),
+            NULLIF(v.customer_name, '')
+          ), ''
+        )                                                              AS description,
+        '/auto-aging/vehicles?search=' ||
+          encode(convert_to(COALESCE(v.chassis_no, q.term), 'UTF8'), 'escape') AS href,
+        (CASE
+          WHEN lower(v.chassis_no) = q.lterm                    THEN 100
+          WHEN lower(v.chassis_no) LIKE q.lterm || '%'          THEN 90
+          ELSE 50
+        END)::int                                                      AS rank_score
+      FROM vehicles v, q
+      WHERE v.deleted_at IS NULL
+        AND (
+          v.chassis_no    ILIKE '%' || q.term || '%'
+          OR v.customer_name ILIKE '%' || q.term || '%'
+          OR v.owner_name    ILIKE '%' || q.term || '%'
+          OR v.model         ILIKE '%' || q.term || '%'
+          OR v.branch_code   ILIKE '%' || q.term || '%'
+        )
+      ORDER BY rank_score DESC
+      LIMIT (SELECT lim FROM q)
+    )
+    UNION ALL
+    -- ── customers ─────────────────────────────────────────────────────
+    (
+      SELECT
+        'customer'::text                                               AS entity_type,
+        c.id::text                                                     AS entity_id,
+        c.name                                                         AS label,
+        NULLIF(concat_ws(' - ', NULLIF(c.phone, ''), NULLIF(c.email, '')), '') AS description,
+        '/sales/customers?search=' ||
+          encode(convert_to(c.name, 'UTF8'), 'escape')                 AS href,
+        (CASE
+          WHEN lower(c.name)  = q.lterm                          THEN 100
+          WHEN lower(c.name)  LIKE q.lterm || '%'                THEN 90
+          WHEN lower(c.email) = q.lterm                          THEN 80
+          ELSE 50
+        END)::int                                                      AS rank_score
+      FROM customers c, q
+      WHERE
+            c.name  ILIKE '%' || q.term || '%'
+        OR c.phone ILIKE '%' || q.term || '%'
+        OR c.email ILIKE '%' || q.term || '%'
+        OR c.ic_no ILIKE '%' || q.term || '%'
+      ORDER BY rank_score DESC
+      LIMIT (SELECT lim FROM q)
+    )
+    UNION ALL
+    -- ── sales_orders ──────────────────────────────────────────────────
+    (
+      SELECT
+        'sales_order'::text                                            AS entity_type,
+        so.id::text                                                    AS entity_id,
+        COALESCE(NULLIF(so.order_no, ''), 'Sales order')               AS label,
+        NULLIF(concat_ws(' - ', NULLIF(so.customer_name, ''), NULLIF(so.model, '')), '') AS description,
+        '/sales/orders?search=' ||
+          encode(convert_to(COALESCE(so.order_no, q.term), 'UTF8'), 'escape') AS href,
+        (CASE
+          WHEN lower(so.order_no)   = q.lterm                    THEN 100
+          WHEN lower(so.order_no)   LIKE q.lterm || '%'          THEN 90
+          ELSE 50
+        END)::int                                                      AS rank_score
+      FROM sales_orders so, q
+      WHERE
+            so.order_no       ILIKE '%' || q.term || '%'
+        OR so.customer_name   ILIKE '%' || q.term || '%'
+        OR so.model           ILIKE '%' || q.term || '%'
+        OR so.chassis_no      ILIKE '%' || q.term || '%'
+        OR so.vso_no          ILIKE '%' || q.term || '%'
+        OR so.plate_no        ILIKE '%' || q.term || '%'
+      ORDER BY rank_score DESC
+      LIMIT (SELECT lim FROM q)
+    )
+    UNION ALL
+    -- ── profiles (admin-only via RLS) ─────────────────────────────────
+    (
+      SELECT
+        'profile'::text                                                AS entity_type,
+        p.id::text                                                     AS entity_id,
+        COALESCE(NULLIF(p.name, ''), p.email)                          AS label,
+        NULLIF(concat_ws(' - ', p.email, replace(p.role::text, '_', ' ')), '') AS description,
+        '/admin/users?search=' ||
+          encode(convert_to(p.email, 'UTF8'), 'escape')                AS href,
+        (CASE
+          WHEN lower(p.email) = q.lterm                          THEN 100
+          WHEN lower(p.email) LIKE q.lterm || '%'                THEN 90
+          WHEN lower(p.name)  = q.lterm                          THEN 80
+          ELSE 50
+        END)::int                                                      AS rank_score
+      FROM profiles p, q
+      WHERE
+            p.email ILIKE '%' || q.term || '%'
+        OR p.name  ILIKE '%' || q.term || '%'
+      ORDER BY rank_score DESC
+      LIMIT (SELECT lim FROM q)
+    )
+  ) results
+  WHERE (SELECT length(term) FROM q) >= 2
+  ORDER BY rank_score DESC, label ASC;
+$$;
+
+REVOKE ALL ON FUNCTION public.global_search(text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.global_search(text, integer)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.global_search(text, integer) IS
+  'Cmd+K global entity search. Returns up to p_limit matches per entity type from vehicles, customers, sales_orders, profiles. SECURITY INVOKER: RLS does the company / role filtering. Min query length: 2.';
+
+-- ─── Indexes for ILIKE substring search ──────────────────────────────────────
+--
+-- ILIKE '%foo%' cannot use a btree index. The pg_trgm extension provides
+-- GIN indexes that accelerate it. The extension is already in use by other
+-- migrations; we add it idempotently here for clarity.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_vehicles_search_trgm
+  ON public.vehicles
+  USING gin (chassis_no gin_trgm_ops, customer_name gin_trgm_ops, owner_name gin_trgm_ops, model gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_customers_search_trgm
+  ON public.customers
+  USING gin (name gin_trgm_ops, phone gin_trgm_ops, email gin_trgm_ops, ic_no gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_sales_orders_search_trgm
+  ON public.sales_orders
+  USING gin (order_no gin_trgm_ops, customer_name gin_trgm_ops, model gin_trgm_ops, chassis_no gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_profiles_search_trgm
+  ON public.profiles
+  USING gin (name gin_trgm_ops, email gin_trgm_ops);


### PR DESCRIPTION
## Phase 2b — global_search RPC

Second subtask of Phase 2. Independent of 2a — different files, different layer.

### What

Replace four fan-out queries in the Cmd+K command palette with one server-side union RPC.

**Before** (`mainShellConfig.ts` `onCommandSearch`):
1. `searchVehicles({ search })` — server RPC
2. `customers.filter(...)` — against the SalesContext cache
3. `salesOrders.filter(...)` — against the SalesContext cache
4. `listProfiles(companyId)` (admin only) — full company roster, then client-side filter

**After**:
1. `globalSearch(query, 6)` — one RPC, RLS-scoped, returns tagged rows from all four entity types

### Schema (`supabase/migrations/20260524020000_global_search.sql`)

```sql
public.global_search(p_query text, p_limit int)
  RETURNS TABLE (entity_type text, entity_id text, label text,
                 description text, href text, rank_score integer)
  SECURITY INVOKER  -- RLS does the company / role filtering
```

- Searches vehicles (chassis_no, customer_name, owner_name, model, branch_code), customers (name, phone, email, ic_no), sales_orders (order_no, customer_name, model, chassis_no, vso_no, plate_no), profiles (name, email).
- Rank: `100` exact → `90` prefix → `50` contains.
- Min query length 2; shorter → empty result set.
- Adds `pg_trgm` GIN indexes on the searched columns so `ILIKE '%x%'` uses an index.

### Why `SECURITY INVOKER` not `DEFINER`

`SECURITY DEFINER` would bypass per-table RLS and require us to re-implement the company / role guards inside the function — a new trust anchor and a re-implementation bug waiting to happen. With `INVOKER`, each `UNION ALL` branch runs as the caller, so:
- Non-admins searching profiles get zero rows (the existing `profiles` SELECT policy enforces it).
- Cross-tenant data leakage is impossible without first breaking the underlying RLS — same threat model as today's pages.

The CI contract check (`scripts/check-rpc-contracts.ts`) now enforces this: `SECURITY DEFINER` on `global_search` is a forbidden pattern; the function signature is required.

### Files

| Layer | Change |
|---|---|
| DB | `supabase/migrations/20260524020000_global_search.sql` (new) |
| Service | `src/services/globalSearchService.ts` (new) + `.test.ts` (new, mocked RPC) |
| UI | `src/components/layout/app-shell/mainShellConfig.ts` (onCommandSearch shrinks ~60 → ~4 lines; drops `useSales`, `textMatches`, `searchVehicles`, `listProfiles` imports) |
| CI | `scripts/check-rpc-contracts.ts` (global_search target added) |

### Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run check:rpc-contracts` passes
- [x] `npm run security:no-service-role` passes
- [ ] Apply migration locally (`supabase db push --local`), regenerate `database.types.ts`, smoke Cmd+K against:
  - `chassi` → vehicle hits
  - a customer name fragment → customer hits
  - an order number prefix → sales_order hits
  - as super_admin: an email fragment → profile hits
  - as sales (non-admin): same email fragment → no profile hits (RLS suppression)
- [ ] `npm run test -- src/services/globalSearchService.test.ts`

### Performance note

The four-fan-out version called `listProfiles(companyId)` which fetched every profile row in the company on every keystroke debounce. For Fook Loi at ~200 staff per company this was ~200 rows × 4 keystrokes per query. The new RPC returns at most `4 × p_limit = 24` rows, scoped at the DB.

### Next subtask
Phase 2c — extract `packages/shell` to dedupe the two AppShell trees (main + hrms-web) and the two `useSupabaseChannel` copies introduced by Phase 2a.

---
_Generated by [Claude Code](https://claude.ai/code/session_0126qBxLNiA2u8QRoUKQwqYg)_