### PR TITLE
feat(requests): overhaul internal-request UI (design system, DnD, New Request rework)

### DIFF
--- a/e2e/tickets.spec.ts
+++ b/e2e/tickets.spec.ts
@@ -83,10 +83,10 @@ test("New Request submits successfully and returns to request history", async ({
   ).toBeVisible({ timeout: 10000 });
 
   await page.getByLabel(/request title/i).fill("Cannot access sales dashboard");
-  const categorySelect = page.getByRole("combobox", { name: /^category/i });
-  await categorySelect.click();
-  await page.getByLabel("General Support").click();
-  await expect(categorySelect).toContainText("General Support");
+  // Category is a dropdown; the only configured category auto-selects.
+  await expect(page.getByRole("combobox", { name: /^category/i })).toContainText("General Support");
+  // Description auto-fills from the category description (no subcategory configured).
+  await expect(page.getByLabel(/description/i)).toHaveValue(/general internal support requests/i);
   await page.getByLabel(/description/i).fill(
     "I get a 403 error whenever I open the sales dashboard after login.",
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "apps/*"
       ],
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@flc/auth": "*",
         "@flc/hrms-schemas": "*",
         "@flc/hrms-services": "*",
@@ -1883,6 +1886,59 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^6.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -17177,8 +17233,11 @@
       "name": "@flc/ui",
       "version": "0.0.0",
       "peerDependencies": {
+        "@flc/types": "*",
+        "lucide-react": "^0.577.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@flc/auth": "*",
     "@flc/hrms-schemas": "*",
     "@flc/hrms-services": "*",

--- a/packages/internal-requests/src/requestCategoryService.ts
+++ b/packages/internal-requests/src/requestCategoryService.ts
@@ -389,3 +389,33 @@ export async function moveRequestCategory(
 
   return { error: null };
 }
+
+/**
+ * Persist an arbitrary new order (e.g. from a drag-and-drop reorder) by
+ * writing `sort_order = index` for each id. App-layer like {@link moveRequestCategory}
+ * — no RPC. Updates run in parallel; the first failure is returned.
+ */
+export async function reorderRequestCategories(
+  orderedIds: string[],
+  context: RequestCategoryContext,
+): Promise<{ error: string | null }> {
+  const timestamp = new Date().toISOString();
+  const results = await Promise.all(
+    orderedIds.map((id, index) =>
+      supabase
+        .from('request_categories')
+        .update({ sort_order: index, updated_by: context.actorId, updated_at: timestamp })
+        .eq('id', id)
+        .eq('company_id', context.companyId),
+    ),
+  );
+  const failed = results.find((result) => result.error);
+  if (failed?.error) return { error: failed.error.message };
+
+  void logUserAction(context.actorId, 'update', 'request_category', orderedIds[0] ?? '', {
+    component: 'RequestCategoryService',
+    reorder: orderedIds.length,
+  });
+
+  return { error: null };
+}

--- a/packages/internal-requests/src/requestRoutingService.ts
+++ b/packages/internal-requests/src/requestRoutingService.ts
@@ -325,6 +325,34 @@ export async function moveRoutingRule(
 }
 
 /**
+ * Persist an arbitrary new evaluation order (e.g. from drag-and-drop) by
+ * writing `sort_order = index` for each id. App-layer like {@link moveRoutingRule}.
+ */
+export async function reorderRoutingRules(
+  orderedIds: string[],
+  context: RoutingRuleContext,
+): Promise<{ error: string | null }> {
+  const timestamp = new Date().toISOString();
+  const results = await Promise.all(
+    orderedIds.map((id, index) =>
+      supabase.from('request_routing_rules')
+        .update({ sort_order: index, updated_at: timestamp })
+        .eq('id', id)
+        .eq('company_id', context.companyId),
+    ),
+  );
+  const failed = results.find((result) => result.error);
+  if (failed?.error) return { error: (failed.error as { message: string }).message };
+
+  void logUserAction(context.actorId, 'update', 'request_routing_rule', orderedIds[0] ?? '', {
+    component: 'RequestRoutingService',
+    reorder: orderedIds.length,
+  });
+
+  return { error: null };
+}
+
+/**
  * Evaluate routing rules in priority order.
  * Returns the assign_to_user_id of the first active matching rule, or null.
  * Gracefully returns null if rules cannot be loaded (ticket is still created unassigned).

--- a/packages/internal-requests/src/requestSubcategoryService.ts
+++ b/packages/internal-requests/src/requestSubcategoryService.ts
@@ -307,3 +307,115 @@ export async function moveRequestSubcategory(
 
   return { error: null };
 }
+
+/**
+ * Persist an arbitrary new order for the subcategories of a single category
+ * (e.g. from drag-and-drop). Writes `sort_order = index` for each id; app-layer
+ * like {@link moveRequestSubcategory}. `categoryKey` scopes the reorder for
+ * the audit log; the writes are keyed by id.
+ */
+export async function reorderRequestSubcategories(
+  categoryKey: string,
+  orderedIds: string[],
+  context: RequestSubcategoryContext,
+): Promise<{ error: string | null }> {
+  const timestamp = new Date().toISOString();
+  const results = await Promise.all(
+    orderedIds.map((id, index) =>
+      supabase
+        .from('request_subcategories')
+        .update({ sort_order: index, updated_by: context.actorId, updated_at: timestamp })
+        .eq('id', id)
+        .eq('company_id', context.companyId),
+    ),
+  );
+  const failed = results.find((result) => result.error);
+  if (failed?.error) return { error: failed.error.message };
+
+  void logUserAction(context.actorId, 'update', 'request_subcategory', orderedIds[0] ?? '', {
+    component: 'RequestSubcategoryService',
+    reorder: orderedIds.length,
+    categoryKey,
+  });
+
+  return { error: null };
+}
+
+export interface DeleteRequestSubcategoryResult {
+  error: string | null;
+  inUse?: boolean;
+  conflict?: boolean;
+}
+
+/**
+ * Deletes a subcategory if no ticket or template references its key. If it is
+ * in use, returns `{ inUse: true }` — the caller should offer deactivation
+ * instead. Scoped `request_form_fields` are removed by the FK `on delete cascade`.
+ * Mirrors {@link deleteRequestCategory}.
+ */
+export async function deleteRequestSubcategory(
+  subcategoryId: string,
+  context: RequestSubcategoryContext,
+  expectedUpdatedAt?: string,
+): Promise<DeleteRequestSubcategoryResult> {
+  const { data: row, error: fetchError } = await supabase
+    .from('request_subcategories')
+    .select('id, category_key, subcategory_key, label')
+    .eq('id', subcategoryId)
+    .eq('company_id', context.companyId)
+    .single();
+
+  if (fetchError || !row) {
+    return { error: 'Subcategory not found.' };
+  }
+
+  const categoryKey = (row as { category_key: string }).category_key;
+  const subcategoryKey = (row as { subcategory_key: string }).subcategory_key;
+  const label = (row as { label: string }).label;
+
+  // Ticket usage — tickets.subcategory stores the subcategory_key.
+  const { count: ticketCount, error: ticketError } = await supabase
+    .from('tickets')
+    .select('id', { count: 'exact', head: true })
+    .eq('company_id', context.companyId)
+    .eq('category', categoryKey)
+    .eq('subcategory', subcategoryKey);
+  if (ticketError) return { error: ticketError.message };
+  if ((ticketCount ?? 0) > 0) {
+    return { error: 'This subcategory has been used in existing requests. Deactivate it instead.', inUse: true };
+  }
+
+  // Template usage.
+  const { count: templateCount, error: templateError } = await supabase
+    .from('request_templates')
+    .select('id', { count: 'exact', head: true })
+    .eq('company_id', context.companyId)
+    .eq('category_key', categoryKey)
+    .eq('subcategory_key', subcategoryKey);
+  if (templateError) return { error: templateError.message };
+  if ((templateCount ?? 0) > 0) {
+    return { error: 'This subcategory is used by one or more templates. Deactivate it instead.', inUse: true };
+  }
+
+  let deleteQuery = supabase
+    .from('request_subcategories')
+    .delete()
+    .eq('id', subcategoryId)
+    .eq('company_id', context.companyId);
+  if (expectedUpdatedAt) deleteQuery = deleteQuery.eq('updated_at', expectedUpdatedAt);
+
+  const { data: deletedRows, error: deleteError } = await deleteQuery.select('id');
+  if (deleteError) return { error: deleteError.message };
+  if (expectedUpdatedAt && (!deletedRows || deletedRows.length === 0)) {
+    return { error: OPTIMISTIC_CONFLICT_MESSAGE, conflict: true };
+  }
+
+  void logUserAction(context.actorId, 'delete', 'request_subcategory', subcategoryId, {
+    component: 'RequestSubcategoryService',
+    category_key: categoryKey,
+    subcategory_key: subcategoryKey,
+    before: { label, subcategory_key: subcategoryKey },
+  });
+
+  return { error: null };
+}

--- a/packages/internal-requests/src/requestTemplateService.ts
+++ b/packages/internal-requests/src/requestTemplateService.ts
@@ -278,6 +278,33 @@ export async function moveRequestTemplate(
   return { error: null };
 }
 
+/**
+ * Persist an arbitrary new order (e.g. from drag-and-drop) by writing
+ * `sort_order = index` for each id. App-layer like {@link moveRequestTemplate}.
+ */
+export async function reorderRequestTemplates(
+  orderedIds: string[],
+  context: RequestTemplateContext,
+): Promise<{ error: string | null }> {
+  const results = await Promise.all(
+    orderedIds.map((id, index) =>
+      requestTemplatesTable()
+        .update({ sort_order: index, updated_by: context.actorId })
+        .eq('id', id)
+        .eq('company_id', context.companyId),
+    ),
+  );
+  const failed = results.find((result: { error: unknown }) => result.error);
+  if (failed?.error) return { error: (failed.error as { message: string }).message };
+
+  void logUserAction(context.actorId, 'update', 'request_template', orderedIds[0] ?? '', {
+    component: 'RequestTemplateService',
+    reorder: orderedIds.length,
+  });
+
+  return { error: null };
+}
+
 export async function deleteRequestTemplate(
   templateId: string,
   context: RequestTemplateContext,

--- a/packages/ui/src/SortableList.tsx
+++ b/packages/ui/src/SortableList.tsx
@@ -1,0 +1,121 @@
+import { type ReactNode } from 'react';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical } from 'lucide-react';
+import { cn } from './lib/utils';
+
+export interface SortableListHelpers {
+  /** Pre-built drag handle — place it anywhere inside the row. */
+  handle: ReactNode;
+  isDragging: boolean;
+}
+
+export interface SortableListProps<T> {
+  items: T[];
+  getId: (item: T) => string;
+  /** Fires with the full id array in its new order after a drop. */
+  onReorder: (orderedIds: string[]) => void;
+  children: (item: T, helpers: SortableListHelpers) => ReactNode;
+  className?: string;
+  /** Disable dragging (e.g. while a mutation is in flight). */
+  disabled?: boolean;
+}
+
+function SortableRow({
+  id,
+  disabled,
+  render,
+}: {
+  id: string;
+  disabled?: boolean;
+  render: (helpers: SortableListHelpers) => ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled,
+  });
+
+  const style = { transform: CSS.Transform.toString(transform), transition };
+
+  const handle = (
+    <button
+      type="button"
+      aria-label="Drag to reorder"
+      disabled={disabled}
+      className="flex h-7 w-7 shrink-0 touch-none cursor-grab items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-40"
+      {...attributes}
+      {...listeners}
+    >
+      <GripVertical className="h-4 w-4" aria-hidden />
+    </button>
+  );
+
+  return (
+    <div ref={setNodeRef} style={style} className={cn(isDragging && 'relative z-10 opacity-80')}>
+      {render({ handle, isDragging })}
+    </div>
+  );
+}
+
+/**
+ * Generic keyboard- and pointer-accessible drag-to-reorder list (built on
+ * @dnd-kit). Render-prop API: each item receives a ready-made `handle` to
+ * place where it likes. On drop, `onReorder` is called with the new ordered
+ * id array — the caller persists it (and typically reorders optimistically).
+ */
+export function SortableList<T>({
+  items,
+  getId,
+  onReorder,
+  children,
+  className,
+  disabled,
+}: SortableListProps<T>) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const ids = items.map(getId);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = ids.indexOf(String(active.id));
+    const newIndex = ids.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+    onReorder(arrayMove(ids, oldIndex, newIndex));
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+        <div className={className}>
+          {items.map((item) => (
+            <SortableRow
+              key={getId(item)}
+              id={getId(item)}
+              disabled={disabled}
+              render={(helpers) => children(item, helpers)}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,6 +14,7 @@ export * from './KpiSkeleton';
 export * from './LocationPreservingNavigate';
 export * from './MobileCardList';
 export * from './ScrollableRegion';
+export * from './SortableList';
 export * from './StandardTable';
 export * from './StepperProgress';
 export * from './TableSkeleton';

--- a/src/components/tickets/RequestBadge.tsx
+++ b/src/components/tickets/RequestBadge.tsx
@@ -1,0 +1,72 @@
+import type { ElementType } from 'react';
+
+import { cn } from '@/lib/utils';
+import { toneClass, type Tone } from '@/lib/statusTones';
+import {
+  requestPriorityLabel,
+  requestPriorityTone,
+  requestStatusLabel,
+  requestStatusTone,
+} from '@/lib/requestTones';
+import type { TicketPriority, TicketStatus } from '@/services/ticketService';
+
+interface RequestBadgeProps {
+  tone: Tone;
+  label: string;
+  icon?: ElementType;
+  className?: string;
+}
+
+/**
+ * Tone-driven status pill for the Internal Request module. Built on the shared
+ * {@link toneClass} system so status/priority/SLA badges stay consistent with
+ * the rest of the suite instead of each call site hand-writing Tailwind colour
+ * pairs.
+ */
+export function RequestBadge({ tone, label, icon: Icon, className }: RequestBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium leading-none',
+        toneClass(tone),
+        className,
+      )}
+    >
+      {Icon && <Icon className="h-3 w-3" aria-hidden />}
+      {label}
+    </span>
+  );
+}
+
+export function RequestStatusBadge({
+  status,
+  icon,
+  className,
+}: {
+  status: TicketStatus;
+  icon?: ElementType;
+  className?: string;
+}) {
+  return (
+    <RequestBadge tone={requestStatusTone(status)} label={requestStatusLabel(status)} icon={icon} className={className} />
+  );
+}
+
+export function RequestPriorityBadge({
+  priority,
+  icon,
+  className,
+}: {
+  priority: TicketPriority;
+  icon?: ElementType;
+  className?: string;
+}) {
+  return (
+    <RequestBadge
+      tone={requestPriorityTone(priority)}
+      label={requestPriorityLabel(priority)}
+      icon={icon}
+      className={className}
+    />
+  );
+}

--- a/src/components/tickets/RequestDetailPanel.tsx
+++ b/src/components/tickets/RequestDetailPanel.tsx
@@ -1,7 +1,6 @@
 import { formatDistanceToNow } from 'date-fns';
 import { CheckCircle2, Loader2, MessageSquare, Send, UserRound, XCircle } from 'lucide-react';
 
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -13,12 +12,8 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { getRequestCategoryLabel } from '@/lib/requestCategories';
 import { getRequestSubcategoryLabel } from '@/lib/requestSubcategories';
-import {
-  customFieldEntries,
-  formatTicketLabel,
-  isOverdue,
-  statusColorMap,
-} from '@/lib/requestFormatters';
+import { customFieldEntries, isOverdue } from '@/lib/requestFormatters';
+import { RequestBadge, RequestStatusBadge } from '@/components/tickets/RequestBadge';
 import { TicketActivityList } from '@/components/tickets/TicketActivityList';
 import { TicketAttachmentList } from '@/components/tickets/TicketAttachmentList';
 import { TicketApprovalHistory } from '@/components/tickets/TicketApprovalHistory';
@@ -98,14 +93,12 @@ export function RequestDetailPanel({
         <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
           <div className="min-w-0 space-y-1.5">
             <div className="flex flex-wrap gap-1.5">
-              <Badge variant="outline" className={`border text-[10px] capitalize ${statusColorMap[ticket.status]}`}>
-                {formatTicketLabel(ticket.status)}
-              </Badge>
-              {isOverdue(ticket) && <Badge variant="destructive" className="text-[10px]">Overdue</Badge>}
+              <RequestStatusBadge status={ticket.status} />
+              {isOverdue(ticket) && <RequestBadge tone="red" label="Overdue" />}
               <TicketApprovalSummary ticket={ticket} compact />
             </div>
             <h2 className={variant === 'drawer' ? 'text-base font-semibold leading-6 text-foreground' : 'text-base font-semibold text-foreground'}>{ticket.subject}</h2>
-            <p className="text-[11px] text-muted-foreground">
+            <p className="text-xs text-muted-foreground">
               Submitted {formatDistanceToNow(new Date(ticket.created_at), { addSuffix: true })}
               {ticket.vso_number ? ` · VSO ${ticket.vso_number}` : ''}
             </p>
@@ -155,7 +148,7 @@ export function RequestDetailPanel({
         {/* Admin controls: status, priority, owner */}
         <div className={`grid gap-2 ${gridColumns}`}>
           <div className="space-y-1.5">
-            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Status</p>
+            <p className="eyebrow">Status</p>
             <Select
               value={ticket.status}
               onValueChange={(value) => onStatusChange(ticket.id, value as TicketStatus)}
@@ -170,7 +163,7 @@ export function RequestDetailPanel({
             </Select>
           </div>
           <div className="space-y-1.5">
-            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Priority</p>
+            <p className="eyebrow">Priority</p>
             <Select
               value={ticket.priority}
               onValueChange={(value) => onPriorityChange(ticket.id, value as TicketPriority)}
@@ -185,7 +178,7 @@ export function RequestDetailPanel({
             </Select>
           </div>
           <div className="space-y-1.5">
-            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Owner</p>
+            <p className="eyebrow">Owner</p>
             <Select
               value={ticket.assigned_to ?? 'unassigned'}
               onValueChange={(value) => onAssignmentChange(ticket.id, value)}
@@ -205,18 +198,18 @@ export function RequestDetailPanel({
         {/* Metadata cards */}
         <div className={`grid gap-2 ${gridColumns}`}>
           <div className="rounded-md border border-border bg-background px-3 py-2">
-            <p className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            <p className="flex items-center gap-1.5 eyebrow">
               <UserRound className="h-3 w-3" />
               Requester
             </p>
             <p className="mt-1 text-sm font-medium text-foreground">{ticket.submitted_by_name ?? 'Unknown requester'}</p>
-            {ticket.submitted_by_email && <p className="truncate text-[11px] text-muted-foreground">{ticket.submitted_by_email}</p>}
+            {ticket.submitted_by_email && <p className="truncate text-xs text-muted-foreground">{ticket.submitted_by_email}</p>}
           </div>
           <div className="rounded-md border border-border bg-background px-3 py-2">
-            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Category</p>
+            <p className="eyebrow">Category</p>
             <p className="mt-1 text-sm font-medium text-foreground">{getRequestCategoryLabel(ticket.category, categories)}</p>
             {ticket.subcategory && (
-              <p className="text-[11px] text-muted-foreground">
+              <p className="text-xs text-muted-foreground">
                 {getRequestSubcategoryLabel(ticket.subcategory, ticket.category, subcategories)}
               </p>
             )}
@@ -226,11 +219,11 @@ export function RequestDetailPanel({
         {/* Additional custom fields */}
         {extraFields.length > 0 && (
           <div className="rounded-md border border-border bg-background px-3 py-2">
-            <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Additional details</p>
+            <p className="eyebrow">Additional details</p>
             <div className={`mt-1.5 grid gap-2 ${twoColumns}`}>
               {extraFields.map((field) => (
                 <div key={field.key} className="min-w-0">
-                  <p className="text-[11px] text-muted-foreground">{field.label}</p>
+                  <p className="text-xs text-muted-foreground">{field.label}</p>
                   <p className={`${additionalFieldValueClass} text-sm text-foreground`}>{field.value}</p>
                 </div>
               ))}
@@ -240,7 +233,7 @@ export function RequestDetailPanel({
 
         {/* Description */}
         <div className="rounded-md border bg-background px-3 py-2">
-          <p className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Request detail</p>
+          <p className="mb-1 eyebrow">Request detail</p>
           <p className="whitespace-pre-line text-sm leading-5 text-foreground">{ticket.description}</p>
         </div>
 
@@ -249,7 +242,7 @@ export function RequestDetailPanel({
           <div className={`grid gap-2 ${twoColumns}`}>
             {ticket.desired_outcome && (
               <div className="rounded-md border border-border px-3 py-2">
-                <p className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                <p className="flex items-center gap-1.5 eyebrow">
                   <CheckCircle2 className="h-3 w-3" />
                   Desired outcome
                 </p>
@@ -258,7 +251,7 @@ export function RequestDetailPanel({
             )}
             {ticket.business_impact && (
               <div className="rounded-md border border-border px-3 py-2">
-                <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Business impact</p>
+                <p className="eyebrow">Business impact</p>
                 <p className="mt-1 text-sm leading-5 text-foreground">{ticket.business_impact}</p>
               </div>
             )}
@@ -269,7 +262,7 @@ export function RequestDetailPanel({
         {(ticket.status === 'resolved' || ticket.status === 'closed' || ticket.resolution_note) && (
           <div className="space-y-2 rounded-md border border-border bg-secondary/20 px-3 py-2.5">
             <div className="flex items-center justify-between gap-3">
-              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Resolution note</p>
+              <p className="eyebrow">Resolution note</p>
               <Button
                 variant="outline"
                 size="sm"
@@ -287,7 +280,7 @@ export function RequestDetailPanel({
               rows={3}
               disabled={saving}
             />
-            <p className="text-[11px] text-muted-foreground">Shown to the requester when their request is resolved or closed.</p>
+            <p className="text-xs text-muted-foreground">Shown to the requester when their request is resolved or closed.</p>
           </div>
         )}
 
@@ -295,7 +288,7 @@ export function RequestDetailPanel({
 
         {/* Comment / discussion */}
         <div className="space-y-2 rounded-md border border-border px-3 py-2.5">
-          <p className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+          <p className="flex items-center gap-1.5 eyebrow">
             <MessageSquare className="h-3 w-3" />
             Discussion
           </p>

--- a/src/components/tickets/RequestQueueMetricGrid.tsx
+++ b/src/components/tickets/RequestQueueMetricGrid.tsx
@@ -1,5 +1,7 @@
+import type { ElementType } from 'react';
 import { AlertTriangle, ClipboardList, Clock3, Inbox, ShieldCheck } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { MetricCard } from '@/components/shared/MetricCard';
+import type { Tone } from '@/lib/statusTones';
 
 interface RequestQueueMetrics {
   active: number;
@@ -13,62 +15,19 @@ interface RequestQueueMetricGridProps {
   metrics: RequestQueueMetrics;
 }
 
-interface MetricItem {
-  label: string;
-  value: number;
-  icon: React.ReactNode;
-  accent?: string;
-}
-
 export function RequestQueueMetricGrid({ metrics }: RequestQueueMetricGridProps) {
-  const items: MetricItem[] = [
-    {
-      label: 'Active',
-      value: metrics.active,
-      icon: <ClipboardList className="h-4 w-4" />,
-      accent: 'text-blue-600 dark:text-blue-400',
-    },
-    {
-      label: 'Unassigned',
-      value: metrics.unassigned,
-      icon: <Inbox className="h-4 w-4" />,
-      accent: metrics.unassigned > 0 ? 'text-amber-600 dark:text-amber-400' : undefined,
-    },
-    {
-      label: 'SLA Breached',
-      value: metrics.slaBreached,
-      icon: <Clock3 className="h-4 w-4" />,
-      accent: metrics.slaBreached > 0 ? 'text-red-600 dark:text-red-400' : undefined,
-    },
-    {
-      label: 'At Risk',
-      value: metrics.slaAtRisk,
-      icon: <AlertTriangle className="h-4 w-4" />,
-      accent: metrics.slaAtRisk > 0 ? 'text-orange-600 dark:text-orange-400' : undefined,
-    },
-    {
-      label: 'Approvals',
-      value: metrics.awaitingApproval,
-      icon: <ShieldCheck className="h-4 w-4" />,
-      accent: metrics.awaitingApproval > 0 ? 'text-purple-600 dark:text-purple-400' : undefined,
-    },
+  const items: Array<{ label: string; value: number; icon: ElementType; tone: Tone }> = [
+    { label: 'Active', value: metrics.active, icon: ClipboardList, tone: 'blue' },
+    { label: 'Unassigned', value: metrics.unassigned, icon: Inbox, tone: metrics.unassigned > 0 ? 'amber' : 'slate' },
+    { label: 'SLA breached', value: metrics.slaBreached, icon: Clock3, tone: metrics.slaBreached > 0 ? 'red' : 'slate' },
+    { label: 'At risk', value: metrics.slaAtRisk, icon: AlertTriangle, tone: metrics.slaAtRisk > 0 ? 'amber' : 'slate' },
+    { label: 'Approvals', value: metrics.awaitingApproval, icon: ShieldCheck, tone: metrics.awaitingApproval > 0 ? 'violet' : 'slate' },
   ];
 
   return (
-    <div className="flex flex-wrap items-stretch gap-2">
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
       {items.map((item) => (
-        <div
-          key={item.label}
-          className="kpi-card flex min-w-[130px] flex-1 items-center gap-3 !p-3"
-        >
-          <div className={cn('shrink-0', item.accent ?? 'text-muted-foreground')}>
-            {item.icon}
-          </div>
-          <div className="min-w-0">
-            <p className="text-lg font-semibold leading-none tabular-nums text-foreground">{item.value}</p>
-            <p className="mt-0.5 text-[11px] text-muted-foreground">{item.label}</p>
-          </div>
-        </div>
+        <MetricCard key={item.label} label={item.label} value={item.value} icon={item.icon} tone={item.tone} />
       ))}
     </div>
   );

--- a/src/components/tickets/TicketActivityList.tsx
+++ b/src/components/tickets/TicketActivityList.tsx
@@ -14,7 +14,7 @@ export function TicketActivityList({ activities }: { activities: TicketActivityR
 
   return (
     <div className="space-y-2">
-      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <p className="eyebrow">
         Activity timeline
       </p>
 

--- a/src/components/tickets/TicketApprovalHistory.tsx
+++ b/src/components/tickets/TicketApprovalHistory.tsx
@@ -19,24 +19,24 @@ function DecisionRow({ decision }: { decision: ApprovalDecision }) {
         <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-500" />
       )}
       <div className="min-w-0">
-        <p className="text-[11px] font-medium text-foreground">
+        <p className="text-sm font-medium text-foreground">
           {decision.stepName ?? `Step ${decision.stepOrder}`}
           <span
             className={cn(
-              'ml-1.5 text-[10px] font-semibold uppercase tracking-wide',
-              approved ? 'text-emerald-600' : 'text-red-500',
+              'ml-1.5 text-xs font-semibold uppercase tracking-wide',
+              approved ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400',
             )}
           >
             {decision.decision}
           </span>
         </p>
-        <p className="text-[11px] text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           {decision.approverName ?? 'Unknown approver'}
           {' · '}
           {formatDistanceToNow(new Date(decision.decidedAt), { addSuffix: true })}
         </p>
         {decision.note && (
-          <p className="mt-0.5 text-[11px] italic text-muted-foreground">
+          <p className="mt-0.5 text-xs italic text-muted-foreground">
             &ldquo;{decision.note}&rdquo;
           </p>
         )}
@@ -64,7 +64,7 @@ export function TicketApprovalHistory({ ticketId }: Props) {
 
   if (isLoading) {
     return (
-      <div className="mt-2 flex items-center gap-2 border-t border-border pt-2 text-[11px] text-muted-foreground">
+      <div className="mt-2 flex items-center gap-2 border-t border-border pt-2 text-xs text-muted-foreground">
         <Loader2 className="h-3 w-3 animate-spin" />
         Loading approval trail…
       </div>
@@ -78,7 +78,7 @@ export function TicketApprovalHistory({ ticketId }: Props) {
 
   return (
     <div className="border-t border-border pt-2.5">
-      <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+      <p className="mb-2 eyebrow">
         Approval trail
       </p>
       <ol className="space-y-2.5">
@@ -91,10 +91,10 @@ export function TicketApprovalHistory({ ticketId }: Props) {
           <li className="flex items-start gap-2">
             <Clock3 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
             <div>
-              <p className="text-[11px] font-medium text-foreground">
+              <p className="text-sm font-medium text-foreground">
                 {approval.currentStepName ?? 'Pending step'}
               </p>
-              <p className="text-[11px] text-muted-foreground">
+              <p className="text-xs text-muted-foreground">
                 {approval.currentApproverRole
                   ? `Awaiting: ${approval.currentApproverRole.replace(/_/g, ' ')}`
                   : 'Awaiting approval'}

--- a/src/components/tickets/TicketApprovalSummary.tsx
+++ b/src/components/tickets/TicketApprovalSummary.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle2, Clock3, ShieldCheck, XCircle } from 'lucide-react';
 
-import { Badge } from '@/components/ui/badge';
-import { cn } from '@/lib/utils';
+import { RequestBadge } from '@/components/tickets/RequestBadge';
+import { approvalTone } from '@/lib/requestTones';
 import type { TicketRecord } from '@/services/ticketService';
 
 interface TicketApprovalSummaryProps {
@@ -17,13 +17,11 @@ export function TicketApprovalSummary({ ticket, compact = false }: TicketApprova
   if (!ticket.approval_status) return null;
 
   const status = ticket.approval_status;
-  const icon = status === 'approved'
-    ? <CheckCircle2 className="h-3.5 w-3.5" />
-    : status === 'rejected'
-      ? <XCircle className="h-3.5 w-3.5" />
-      : status === 'cancelled'
-        ? <XCircle className="h-3.5 w-3.5" />
-        : <Clock3 className="h-3.5 w-3.5" />;
+  const Icon = status === 'approved'
+    ? CheckCircle2
+    : status === 'rejected' || status === 'cancelled'
+      ? XCircle
+      : Clock3;
 
   const label = status === 'pending'
     ? 'Approval pending'
@@ -35,33 +33,18 @@ export function TicketApprovalSummary({ ticket, compact = false }: TicketApprova
   const waitingFor = ticket.current_approval_step_name
     ?? (ticket.current_approver_role ? formatRole(ticket.current_approver_role) : null);
 
-  const stateClassName = cn(
-    'inline-flex items-center gap-1.5',
-    status === 'approved' && 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300',
-    status === 'pending' && 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300',
-    (status === 'rejected' || status === 'cancelled') && 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300',
-  );
-
   if (compact) {
-    return (
-      <Badge variant="outline" className={stateClassName}>
-        {icon}
-        {label}
-      </Badge>
-    );
+    return <RequestBadge tone={approvalTone(status)} label={label} icon={Icon} />;
   }
 
   return (
     <div className="rounded-lg border border-border px-3 py-2.5">
-      <p className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <p className="eyebrow flex items-center gap-2">
         <ShieldCheck className="h-3.5 w-3.5" />
         Approval
       </p>
       <div className="mt-2 flex flex-wrap items-center gap-2">
-        <Badge variant="outline" className={stateClassName}>
-          {icon}
-          {label}
-        </Badge>
+        <RequestBadge tone={approvalTone(status)} label={label} icon={Icon} />
         {status === 'pending' && waitingFor && (
           <span className="text-sm text-muted-foreground">Current step: {waitingFor}</span>
         )}

--- a/src/components/tickets/TicketAttachmentList.tsx
+++ b/src/components/tickets/TicketAttachmentList.tsx
@@ -31,7 +31,7 @@ export function TicketAttachmentList({ attachments }: { attachments: TicketAttac
 
   return (
     <div className="rounded-lg border border-border px-3 py-2.5">
-      <p className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <p className="eyebrow flex items-center gap-2">
         <Paperclip className="h-3.5 w-3.5" />
         Attachments ({attachments.length})
       </p>

--- a/src/components/tickets/TicketSlaSummary.tsx
+++ b/src/components/tickets/TicketSlaSummary.tsx
@@ -1,21 +1,13 @@
 import { Clock3 } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
+import { RequestBadge } from '@/components/tickets/RequestBadge';
+import { slaTone } from '@/lib/requestTones';
 import {
   formatSlaCompactLabel,
   formatSlaCheck,
   formatSlaState,
   getTicketSlaSummary,
   type TicketSlaInput,
-  type TicketSlaState,
 } from '@/lib/ticketSla';
-
-const slaVariant: Record<TicketSlaState, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  breached: 'destructive',
-  at_risk: 'secondary',
-  pending: 'outline',
-  met: 'outline',
-  not_configured: 'outline',
-};
 
 interface TicketSlaSummaryProps {
   ticket: TicketSlaInput;
@@ -26,22 +18,17 @@ export function TicketSlaSummary({ ticket, compact = false }: TicketSlaSummaryPr
   const sla = getTicketSlaSummary(ticket);
 
   if (compact) {
-    return (
-      <Badge variant={slaVariant[sla.overall]} className="inline-flex items-center gap-1">
-        <Clock3 className="h-3 w-3" />
-        {formatSlaCompactLabel(sla)}
-      </Badge>
-    );
+    return <RequestBadge tone={slaTone(sla.overall)} label={formatSlaCompactLabel(sla)} icon={Clock3} />;
   }
 
   return (
     <div className="rounded-lg border border-border px-3 py-2.5">
       <div className="flex items-center justify-between gap-3">
-        <p className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <p className="eyebrow flex items-center gap-2">
           <Clock3 className="h-3.5 w-3.5" />
           SLA
         </p>
-        <Badge variant={slaVariant[sla.overall]}>{formatSlaState(sla.overall)}</Badge>
+        <RequestBadge tone={slaTone(sla.overall)} label={formatSlaState(sla.overall)} />
       </div>
       <div className="mt-2 grid gap-2 text-sm md:grid-cols-2">
         <div>

--- a/src/index.css
+++ b/src/index.css
@@ -188,6 +188,11 @@
   .status-badge {
     @apply inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold;
   }
+  /* Canonical small-caps eyebrow/label. Use instead of ad-hoc
+     text-[11px]/text-[10px] uppercase label styling. */
+  .eyebrow {
+    @apply text-[11px] font-semibold uppercase tracking-wider text-muted-foreground;
+  }
   .executive-gradient {
     @apply bg-card;
   }

--- a/src/lib/requestTones.ts
+++ b/src/lib/requestTones.ts
@@ -1,0 +1,84 @@
+/**
+ * Single source of truth for Internal Request status / priority / SLA
+ * presentation: maps each enum to a shared {@link Tone} and a human-readable
+ * label.
+ *
+ * Replaces the ad-hoc `statusColorMap` / `priorityColorMap` Tailwind-string
+ * maps in requestFormatters and the scattered `.charAt(0).toUpperCase()` /
+ * `.replace(/_/g, ' ')` label hacks across the tickets module. Render through
+ * <RequestBadge> / <RequestStatusBadge> / <RequestPriorityBadge> rather than
+ * hand-writing colour pairs at each call site.
+ */
+import type { Tone } from '@/lib/statusTones';
+import type { TicketPriority, TicketStatus } from '@/services/ticketService';
+import type { TicketSlaState } from '@/lib/ticketSla';
+
+// ── Status ──────────────────────────────────────────────────────────────────
+
+const STATUS_TONE: Record<TicketStatus, Tone> = {
+  open: 'blue',
+  in_progress: 'violet',
+  awaiting_requester: 'amber',
+  resolved: 'emerald',
+  closed: 'slate',
+  cancelled: 'slate',
+};
+
+const STATUS_LABEL: Record<TicketStatus, string> = {
+  open: 'Open',
+  in_progress: 'In progress',
+  awaiting_requester: 'Awaiting reply',
+  resolved: 'Resolved',
+  closed: 'Closed',
+  cancelled: 'Cancelled',
+};
+
+export const requestStatusTone = (status: TicketStatus): Tone => STATUS_TONE[status] ?? 'muted';
+export const requestStatusLabel = (status: TicketStatus): string => STATUS_LABEL[status] ?? status;
+
+// ── Priority ──────────────────────────────────────────────────────────────────
+
+const PRIORITY_TONE: Record<TicketPriority, Tone> = {
+  low: 'slate',
+  medium: 'amber',
+  high: 'red',
+};
+
+const PRIORITY_LABEL: Record<TicketPriority, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+};
+
+export const requestPriorityTone = (priority: TicketPriority): Tone => PRIORITY_TONE[priority] ?? 'muted';
+export const requestPriorityLabel = (priority: TicketPriority): string => PRIORITY_LABEL[priority] ?? priority;
+
+// ── SLA ─────────────────────────────────────────────────────────────────────
+
+const SLA_TONE: Record<TicketSlaState, Tone> = {
+  breached: 'red',
+  at_risk: 'amber',
+  pending: 'blue',
+  met: 'emerald',
+  not_configured: 'slate',
+};
+
+export const slaTone = (state: TicketSlaState): Tone => SLA_TONE[state] ?? 'muted';
+
+// ── Approval ──────────────────────────────────────────────────────────────────
+
+/** Tone for an approval workflow status (`approval_status` is loosely typed as string | null). */
+export const approvalTone = (status: string | null | undefined): Tone => {
+  switch (status) {
+    case 'approved':
+      return 'emerald';
+    case 'pending':
+      return 'amber';
+    case 'rejected':
+      return 'red';
+    case 'cancelled':
+      return 'slate';
+    default:
+      return 'muted';
+  }
+};

--- a/src/pages/tickets/MyTickets.tsx
+++ b/src/pages/tickets/MyTickets.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { STALE } from '@/lib/queryClient';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
 import {
   AlertCircle,
   CalendarDays,
   CheckCircle2,
-  ChevronDown,
-  ChevronRight,
+  Inbox,
   Loader2,
   MessageSquare,
   Plus,
@@ -20,7 +19,6 @@ import {
 } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -40,11 +38,24 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Textarea } from '@/components/ui/textarea';
+import { PageHeader } from '@/components/shared/PageHeader';
+import { MetricCard } from '@/components/shared/MetricCard';
+import { HrmsEmptyState } from '@/components/shared/HrmsEmptyState';
+import { StandardTable, type StandardTableColumn } from '@/components/shared/StandardTable';
+import { TableSkeleton } from '@/components/ui/TableSkeleton';
+import { RequestBadge, RequestPriorityBadge, RequestStatusBadge } from '@/components/tickets/RequestBadge';
 import { TicketActivityList } from '@/components/tickets/TicketActivityList';
 import { TicketAttachmentList } from '@/components/tickets/TicketAttachmentList';
 import { TicketApprovalSummary } from '@/components/tickets/TicketApprovalSummary';
 import { TicketSlaSummary } from '@/components/tickets/TicketSlaSummary';
-import { Textarea } from '@/components/ui/textarea';
 import { useRequestCategories } from '@/hooks/useRequestCategories';
 import { useRequestFormFields } from '@/hooks/useRequestFormFields';
 import { useRequestSubcategories } from '@/hooks/useRequestSubcategories';
@@ -54,9 +65,6 @@ import { getRequestCategoryLabel } from '@/lib/requestCategories';
 
 import {
   formatDueDate,
-  formatTicketLabel,
-  statusColorMap,
-  priorityColorMap,
   customFieldEntries,
   isOpenStatus,
 } from '@/lib/requestFormatters';
@@ -65,6 +73,7 @@ import {
   cancelMyTicket,
   listMyTickets,
   listTicketActivity,
+  type RequestTicketRecord,
   type TicketActivityRecord,
 } from '@/services/ticketService';
 import { listAttachmentsForTickets, type TicketAttachmentRecord } from '@flc/platform-services';
@@ -73,6 +82,7 @@ type MyStatusFilter = 'all' | 'active' | 'resolved' | 'cancelled';
 
 export default function MyTickets() {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { categories } = useRequestCategories(user?.company_id, true);
   useRequestSubcategories(user?.company_id, { includeInactive: true });
@@ -85,7 +95,7 @@ export default function MyTickets() {
   );
   const [savingCommentId, setSavingCommentId] = useState<string | null>(null);
   const [cancellingTicketId, setCancellingTicketId] = useState<string | null>(null);
-  const [expandedTicketId, setExpandedTicketId] = useState<string | null>(null);
+  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState<MyStatusFilter>('all');
 
@@ -233,66 +243,120 @@ export default function MyTickets() {
     });
   }, [tickets, searchTerm, statusFilter, categories]);
 
-  const isExpanded = (ticketId: string) => expandedTicketId === ticketId;
-  const toggleExpand = (ticketId: string) => {
-    setExpandedTicketId((current) => (current === ticketId ? null : ticketId));
-  };
+  const selectedTicket = useMemo(
+    () => filteredTickets.find((ticket) => ticket.id === selectedTicketId) ?? null,
+    [filteredTickets, selectedTicketId],
+  );
+
+  const columns = useMemo<StandardTableColumn<RequestTicketRecord>[]>(() => [
+    {
+      key: 'subject',
+      label: 'Request',
+      className: 'min-w-[240px] max-w-[420px]',
+      render: (ticket) => (
+        <div className="min-w-0">
+          <p className="truncate font-medium text-foreground">{ticket.subject}</p>
+          <p className="truncate text-xs text-muted-foreground">
+            {ticket.assigned_to_name ? `Owner: ${ticket.assigned_to_name}` : 'Awaiting assignment'}
+            {ticket.vso_number ? ` · VSO ${ticket.vso_number}` : ''}
+          </p>
+        </div>
+      ),
+    },
+    {
+      key: 'category',
+      label: 'Category',
+      render: (ticket) => (
+        <span className="text-sm text-foreground">{getRequestCategoryLabel(ticket.category, categories)}</span>
+      ),
+    },
+    {
+      key: 'priority',
+      label: 'Priority',
+      render: (ticket) => <RequestPriorityBadge priority={ticket.priority} />,
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      render: (ticket) => <RequestStatusBadge status={ticket.status} />,
+    },
+    {
+      key: 'created_at',
+      label: 'Submitted',
+      className: 'text-right',
+      render: (ticket) => (
+        <span className="whitespace-nowrap text-xs text-muted-foreground">
+          {formatDistanceToNow(new Date(ticket.created_at), { addSuffix: true })}
+        </span>
+      ),
+    },
+  ], [categories]);
+
+  const metrics: Array<{ key: MyStatusFilter; label: string; value: number; icon: React.ElementType; tone: 'slate' | 'blue' | 'emerald'; hint?: string }> = [
+    { key: 'all', label: 'Total', value: counts.all, icon: Ticket, tone: 'slate' },
+    { key: 'active', label: 'Active', value: counts.active, icon: Inbox, tone: 'blue', hint: 'In progress or awaiting you' },
+    { key: 'resolved', label: 'Resolved', value: counts.resolved, icon: CheckCircle2, tone: 'emerald' },
+    { key: 'cancelled', label: 'Cancelled', value: counts.cancelled, icon: XCircle, tone: 'slate' },
+  ];
+
+  const selectedExtraFields = selectedTicket ? customFieldEntries(selectedTicket, customFieldLabelMap) : [];
+  const selectedCanCancel = selectedTicket?.status === 'open' && !selectedTicket.assigned_to;
 
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
-    <div className="flex h-full w-full flex-col gap-2">
-      {/* ── Header ──────────────────────────────────────────── */}
-      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 rounded-lg border bg-card px-4 py-2.5 shadow-sm">
-        <div className="min-w-0">
-          <h1 className="text-base font-semibold tracking-tight text-foreground">My Requests</h1>
-          <p className="text-[11px] text-muted-foreground">Track your submitted requests and follow up</p>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <Button variant="outline" size="sm" className="h-8 gap-1.5 text-xs" onClick={() => void refreshTickets()} disabled={loading}>
-            <RefreshCcw className="h-3.5 w-3.5" />
-            Refresh
-          </Button>
-          <Button asChild size="sm" className="h-8 gap-1.5 text-xs">
-            <Link to="/portal/tickets/new">
-              <Plus className="h-3.5 w-3.5" />
-              New Request
-            </Link>
-          </Button>
-        </div>
-      </div>
+    <div className="flex h-full w-full flex-col gap-4">
+      <PageHeader
+        title="My Requests"
+        description="Track your submitted requests and follow up"
+        breadcrumbs={[{ label: 'Internal Requests', path: '/portal' }, { label: 'My Requests' }]}
+        actions={
+          <>
+            <Button variant="outline" size="sm" className="gap-1.5" onClick={() => void refreshTickets()} disabled={loading}>
+              <RefreshCcw className="h-4 w-4" />
+              Refresh
+            </Button>
+            <Button asChild size="sm" className="gap-1.5">
+              <Link to="/portal/tickets/new">
+                <Plus className="h-4 w-4" />
+                New request
+              </Link>
+            </Button>
+          </>
+        }
+      />
 
-      {/* ── Summary stats ───────────────────────────────────── */}
+      {/* Metric strip — also acts as a status filter */}
       {!loading && !error && tickets.length > 0 && (
-        <div className="flex flex-wrap items-stretch gap-2">
-          {[
-            { label: 'Total', value: counts.all, color: 'text-foreground' },
-            { label: 'Active', value: counts.active, color: counts.active > 0 ? 'text-blue-600 dark:text-blue-400' : 'text-muted-foreground' },
-            { label: 'Resolved', value: counts.resolved, color: counts.resolved > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground' },
-            { label: 'Cancelled', value: counts.cancelled, color: 'text-muted-foreground' },
-          ].map((stat) => (
-            <div key={stat.label} className="kpi-card flex min-w-[100px] flex-1 items-center gap-2.5 !p-2.5">
-              <p className={`text-lg font-semibold tabular-nums leading-none ${stat.color}`}>{stat.value}</p>
-              <p className="text-[11px] text-muted-foreground">{stat.label}</p>
-            </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {metrics.map((metric) => (
+            <MetricCard
+              key={metric.key}
+              label={metric.label}
+              value={metric.value}
+              icon={metric.icon}
+              tone={metric.tone}
+              hint={metric.hint}
+              onClick={() => setStatusFilter(metric.key)}
+            />
           ))}
         </div>
       )}
 
-      {/* ── Filters ─────────────────────────────────────────── */}
+      {/* Filter bar */}
       {!loading && !error && tickets.length > 0 && (
-        <div className="flex flex-col gap-2 rounded-lg border bg-card p-2.5 shadow-sm sm:flex-row sm:items-center">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <div className="relative flex-1">
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
+              onChange={(event) => setSearchTerm(event.target.value)}
               placeholder="Search by subject, category, VSO..."
               className="h-9 pl-9"
             />
           </div>
-          <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as MyStatusFilter)}>
-            <SelectTrigger className="h-9 w-[160px]">
+          <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value as MyStatusFilter)}>
+            <SelectTrigger className="h-9 w-full sm:w-[180px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -305,259 +369,188 @@ export default function MyTickets() {
         </div>
       )}
 
-      {/* ── Content ─────────────────────────────────────────── */}
+      {/* Content */}
       {loading ? (
-        <div className="flex flex-1 items-center justify-center gap-3 rounded-lg border bg-card py-16 text-muted-foreground shadow-sm">
-          <Loader2 className="h-5 w-5 animate-spin" />
-          <span className="text-sm">Loading your requests...</span>
-        </div>
+        <TableSkeleton rows={6} cols={5} />
       ) : error ? (
-        <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-lg border bg-card py-16 text-center shadow-sm">
-          <AlertCircle className="h-8 w-8 text-destructive" />
-          <div className="space-y-1">
-            <p className="font-medium text-foreground">Unable to load requests</p>
-            <p className="text-sm text-muted-foreground">{error}</p>
-          </div>
-          <Button onClick={() => void refreshTickets()} variant="outline" className="gap-2">
-            <RefreshCcw className="h-4 w-4" />
-            Retry
-          </Button>
-        </div>
+        <HrmsEmptyState
+          icon={AlertCircle}
+          title="Unable to load requests"
+          description={error}
+          action={{ label: 'Retry', onClick: () => void refreshTickets() }}
+        />
       ) : tickets.length === 0 ? (
-        <div className="flex flex-1 flex-col items-center justify-center gap-3 rounded-lg border bg-card py-16 text-center shadow-sm">
-          <Ticket className="h-8 w-8 text-muted-foreground" />
-          <div className="space-y-1">
-            <p className="font-medium text-foreground">No requests yet</p>
-            <p className="text-sm text-muted-foreground">
-              Submit a new internal request from the New Request page.
-            </p>
-          </div>
-          <Button asChild size="sm" className="gap-2">
-            <Link to="/portal/tickets/new">
-              <Plus className="h-4 w-4" />
-              New Request
-            </Link>
-          </Button>
-        </div>
-      ) : filteredTickets.length === 0 ? (
-        <div className="flex flex-1 flex-col items-center justify-center gap-3 rounded-lg border bg-card py-12 text-center shadow-sm">
-          <Search className="h-6 w-6 text-muted-foreground" />
-          <p className="text-sm text-muted-foreground">No requests match your search or filter.</p>
-        </div>
+        <HrmsEmptyState
+          icon={Ticket}
+          title="No requests yet"
+          description="Submit a new internal request to get started."
+          action={{ label: 'New request', onClick: () => navigate('/portal/tickets/new') }}
+        />
       ) : (
-        <div className="flex-1 overflow-auto rounded-lg border bg-card shadow-sm">
-          {/* Table header */}
-          <div className="sticky top-0 z-10 grid grid-cols-[1fr_auto_auto_auto_auto] items-center gap-3 border-b bg-muted/50 px-3 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground backdrop-blur sm:grid-cols-[1fr_120px_90px_100px_100px]">
-            <span>Request</span>
-            <span className="hidden sm:block">Category</span>
-            <span className="hidden sm:block">Priority</span>
-            <span className="hidden sm:block">Status</span>
-            <span className="text-right">Date</span>
-          </div>
+        <StandardTable
+          data={filteredTickets}
+          columns={columns}
+          rowKey="id"
+          hideSearch
+          mobileLayout="cards"
+          emptyMessage="No requests match your search or filter."
+          onRowClick={(ticket) => setSelectedTicketId(ticket.id)}
+        />
+      )}
 
-          {/* Rows */}
-          {filteredTickets.map((ticket) => {
-            const expanded = isExpanded(ticket.id);
-            const extraFields = customFieldEntries(ticket, customFieldLabelMap);
-            const canCancel = ticket.status === 'open' && !ticket.assigned_to;
+      {/* Request detail drawer */}
+      <Sheet
+        open={!!selectedTicket}
+        onOpenChange={(open) => {
+          if (!open) setSelectedTicketId(null);
+        }}
+      >
+        <SheetContent side="right" className="w-full gap-0 overflow-y-auto p-0 sm:max-w-xl">
+          {selectedTicket && (
+            <>
+              <SheetHeader className="space-y-2 border-b border-border px-5 py-4 text-left">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <RequestStatusBadge status={selectedTicket.status} />
+                  <RequestPriorityBadge priority={selectedTicket.priority} />
+                  {selectedTicket.requested_due_date && (
+                    <RequestBadge
+                      tone="slate"
+                      icon={CalendarDays}
+                      label={`Due ${formatDueDate(selectedTicket.requested_due_date)}`}
+                    />
+                  )}
+                </div>
+                <SheetTitle className="text-base leading-6">{selectedTicket.subject}</SheetTitle>
+                <SheetDescription>
+                  {getRequestCategoryLabel(selectedTicket.category, categories)}
+                  {' · Submitted '}
+                  {formatDistanceToNow(new Date(selectedTicket.created_at), { addSuffix: true })}
+                  {selectedTicket.vso_number ? ` · VSO ${selectedTicket.vso_number}` : ''}
+                </SheetDescription>
+              </SheetHeader>
 
-            return (
-              <div key={ticket.id} className="border-b border-border last:border-b-0">
-                {/* Compact row */}
-                <button
-                  type="button"
-                  onClick={() => toggleExpand(ticket.id)}
-                  className={`w-full grid grid-cols-[1fr_auto] items-center gap-2 px-3 py-2.5 text-left transition-colors sm:grid-cols-[1fr_120px_90px_100px_100px] ${
-                    expanded ? 'bg-primary/[0.03]' : 'hover:bg-muted/40'
-                  }`}
-                >
-                  <div className="flex min-w-0 items-center gap-2">
-                    {expanded
-                      ? <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                      : <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                    }
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium text-foreground">{ticket.subject}</p>
-                      <p className="truncate text-[11px] text-muted-foreground">
-                        {ticket.assigned_to_name ? `Owner: ${ticket.assigned_to_name}` : 'Awaiting assignment'}
-                        {ticket.vso_number ? ` · VSO ${ticket.vso_number}` : ''}
-                      </p>
-                    </div>
-                  </div>
-                  <span className="hidden truncate text-xs text-muted-foreground capitalize sm:block">
-                    {getRequestCategoryLabel(ticket.category, categories)}
-                  </span>
-                  <span className="hidden sm:block">
-                    <Badge variant="outline" className={`border text-[10px] capitalize ${priorityColorMap[ticket.priority]}`}>
-                      {ticket.priority}
-                    </Badge>
-                  </span>
-                  <span className="hidden sm:block">
-                    <Badge variant="outline" className={`border text-[10px] capitalize ${statusColorMap[ticket.status]}`}>
-                      {formatTicketLabel(ticket.status)}
-                    </Badge>
-                  </span>
-                  <div className="text-right">
-                    <p className="text-[11px] text-muted-foreground">
-                      {formatDistanceToNow(new Date(ticket.created_at), { addSuffix: true })}
-                    </p>
-                    {/* Mobile badges */}
-                    <div className="mt-0.5 flex justify-end gap-1 sm:hidden">
-                      <Badge variant="outline" className={`border text-[9px] capitalize ${statusColorMap[ticket.status]}`}>
-                        {formatTicketLabel(ticket.status)}
-                      </Badge>
-                      <Badge variant="outline" className={`border text-[9px] capitalize ${priorityColorMap[ticket.priority]}`}>
-                        {ticket.priority}
-                      </Badge>
-                    </div>
-                  </div>
-                </button>
+              <div className="space-y-3 px-5 py-4">
+                <div className="rounded-md border bg-background px-3 py-2">
+                  <p className="eyebrow mb-1">Description</p>
+                  <p className="whitespace-pre-line text-sm leading-5 text-foreground">{selectedTicket.description}</p>
+                </div>
 
-                {/* Expanded detail */}
-                {expanded && (
-                  <div className="border-t border-border bg-muted/10 px-4 py-3 sm:pl-10">
-                    <div className="space-y-3">
-                      {/* Badges row */}
-                      <div className="flex flex-wrap gap-1.5">
-                        <TicketApprovalSummary ticket={ticket} compact />
-                        <TicketSlaSummary ticket={ticket} compact />
-                        {ticket.requested_due_date && (
-                          <Badge variant="outline" className="gap-1 text-[10px]">
-                            <CalendarDays className="h-3 w-3" />
-                            Due {formatDueDate(ticket.requested_due_date)}
-                          </Badge>
-                        )}
-                        {canCancel && (
-                          <AlertDialog>
-                            <AlertDialogTrigger asChild>
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                className="h-6 gap-1 text-[10px] text-destructive hover:text-destructive"
-                                disabled={cancellingTicketId === ticket.id}
-                              >
-                                {cancellingTicketId === ticket.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <XCircle className="h-3 w-3" />}
-                                Cancel
-                              </Button>
-                            </AlertDialogTrigger>
-                            <AlertDialogContent>
-                              <AlertDialogHeader>
-                                <AlertDialogTitle>Cancel request?</AlertDialogTitle>
-                                <AlertDialogDescription>
-                                  This request is still open and unassigned. Cancelling it will close the request and remove it from the active queue.
-                                </AlertDialogDescription>
-                              </AlertDialogHeader>
-                              <AlertDialogFooter>
-                                <AlertDialogCancel>Keep request</AlertDialogCancel>
-                                <AlertDialogAction
-                                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                                  onClick={() => void handleCancelTicket(ticket.id)}
-                                >
-                                  Cancel request
-                                </AlertDialogAction>
-                              </AlertDialogFooter>
-                            </AlertDialogContent>
-                          </AlertDialog>
-                        )}
+                <TicketSlaSummary ticket={selectedTicket} />
+                <TicketApprovalSummary ticket={selectedTicket} />
+
+                {(selectedTicket.desired_outcome || selectedTicket.business_impact) && (
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {selectedTicket.desired_outcome && (
+                      <div className="rounded-md border border-border bg-background px-3 py-2">
+                        <p className="eyebrow flex items-center gap-1.5">
+                          <CheckCircle2 className="h-3 w-3" />
+                          Desired outcome
+                        </p>
+                        <p className="mt-1 text-sm leading-5 text-foreground">{selectedTicket.desired_outcome}</p>
                       </div>
-
-                      {/* Description */}
-                      <div className="rounded-md border bg-background px-3 py-2">
-                        <p className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Description</p>
-                        <p className="whitespace-pre-line text-sm leading-5 text-foreground">{ticket.description}</p>
+                    )}
+                    {selectedTicket.business_impact && (
+                      <div className="rounded-md border border-border bg-background px-3 py-2">
+                        <p className="eyebrow">Business impact</p>
+                        <p className="mt-1 text-sm leading-5 text-foreground">{selectedTicket.business_impact}</p>
                       </div>
+                    )}
+                  </div>
+                )}
 
-                      <TicketSlaSummary ticket={ticket} />
-                      <TicketApprovalSummary ticket={ticket} />
-
-                      {/* Desired outcome / Business impact */}
-                      {(ticket.desired_outcome || ticket.business_impact) && (
-                        <div className="grid gap-2 md:grid-cols-2">
-                          {ticket.desired_outcome && (
-                            <div className="rounded-md border border-border bg-background px-3 py-2">
-                              <p className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                                <CheckCircle2 className="h-3 w-3" />
-                                Desired outcome
-                              </p>
-                              <p className="mt-1 text-sm leading-5 text-foreground">{ticket.desired_outcome}</p>
-                            </div>
-                          )}
-                          {ticket.business_impact && (
-                            <div className="rounded-md border border-border bg-background px-3 py-2">
-                              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Business impact</p>
-                              <p className="mt-1 text-sm leading-5 text-foreground">{ticket.business_impact}</p>
-                            </div>
-                          )}
+                {selectedExtraFields.length > 0 && (
+                  <div className="rounded-md border border-border bg-background px-3 py-2">
+                    <p className="eyebrow">Additional details</p>
+                    <div className="mt-1.5 grid gap-2 sm:grid-cols-2">
+                      {selectedExtraFields.map((field) => (
+                        <div key={field.key} className="min-w-0">
+                          <p className="text-xs text-muted-foreground">{field.label}</p>
+                          <p className="truncate text-sm text-foreground">{field.value}</p>
                         </div>
-                      )}
-
-                      {/* Custom fields */}
-                      {extraFields.length > 0 && (
-                        <div className="rounded-md border border-border bg-background px-3 py-2">
-                          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Additional details</p>
-                          <div className="mt-1.5 grid gap-2 md:grid-cols-2">
-                            {extraFields.map((field) => (
-                              <div key={field.key} className="min-w-0">
-                                <p className="text-[11px] text-muted-foreground">{field.label}</p>
-                                <p className="truncate text-sm text-foreground">{field.value}</p>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Resolution note */}
-                      {ticket.resolution_note && (
-                        <div className="rounded-md border border-border bg-secondary/30 px-3 py-2">
-                          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Resolution note</p>
-                          <p className="mt-1 text-sm leading-5 text-foreground">{ticket.resolution_note}</p>
-                        </div>
-                      )}
-
-                      <TicketAttachmentList attachments={attachmentsByTicket[ticket.id] ?? []} />
-
-                      {/* Discussion */}
-                      {ticket.status !== 'closed' && ticket.status !== 'cancelled' && (
-                        <div className="space-y-2 rounded-md border border-border bg-background px-3 py-2.5">
-                          <p className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                            <MessageSquare className="h-3 w-3" />
-                            Discussion
-                          </p>
-                          <Textarea
-                            value={commentDrafts[ticket.id] ?? ''}
-                            onChange={(event) => setCommentDrafts((current) => ({
-                              ...current,
-                              [ticket.id]: event.target.value,
-                            }))}
-                            placeholder="Add a clarification or follow-up note."
-                            rows={3}
-                            disabled={savingCommentId === ticket.id}
-                          />
-                          <div className="flex justify-end">
-                            <Button
-                              type="button"
-                              size="sm"
-                              className="h-8 gap-1.5 text-xs"
-                              onClick={() => void handleAddComment(ticket.id)}
-                              disabled={savingCommentId === ticket.id || !commentDrafts[ticket.id]?.trim()}
-                            >
-                              {savingCommentId === ticket.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
-                              Add comment
-                            </Button>
-                          </div>
-                        </div>
-                      )}
-
-                      <TicketActivityList activities={activitiesByTicket[ticket.id] ?? []} />
+                      ))}
                     </div>
                   </div>
                 )}
+
+                {selectedTicket.resolution_note && (
+                  <div className="rounded-md border border-border bg-secondary/30 px-3 py-2">
+                    <p className="eyebrow">Resolution note</p>
+                    <p className="mt-1 text-sm leading-5 text-foreground">{selectedTicket.resolution_note}</p>
+                  </div>
+                )}
+
+                <TicketAttachmentList attachments={attachmentsByTicket[selectedTicket.id] ?? []} />
+
+                {selectedTicket.status !== 'closed' && selectedTicket.status !== 'cancelled' && (
+                  <div className="space-y-2 rounded-md border border-border bg-background px-3 py-2.5">
+                    <p className="eyebrow flex items-center gap-1.5">
+                      <MessageSquare className="h-3 w-3" />
+                      Discussion
+                    </p>
+                    <Textarea
+                      value={commentDrafts[selectedTicket.id] ?? ''}
+                      onChange={(event) =>
+                        setCommentDrafts((current) => ({ ...current, [selectedTicket.id]: event.target.value }))
+                      }
+                      placeholder="Add a clarification or follow-up note."
+                      rows={3}
+                      disabled={savingCommentId === selectedTicket.id}
+                    />
+                    <div className="flex justify-end">
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="gap-1.5"
+                        onClick={() => void handleAddComment(selectedTicket.id)}
+                        disabled={savingCommentId === selectedTicket.id || !commentDrafts[selectedTicket.id]?.trim()}
+                      >
+                        {savingCommentId === selectedTicket.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+                        Add comment
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                <TicketActivityList activities={activitiesByTicket[selectedTicket.id] ?? []} />
+
+                {selectedCanCancel && (
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="w-full gap-1.5 text-destructive hover:text-destructive"
+                        disabled={cancellingTicketId === selectedTicket.id}
+                      >
+                        {cancellingTicketId === selectedTicket.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <XCircle className="h-3.5 w-3.5" />}
+                        Cancel request
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Cancel request?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This request is still open and unassigned. Cancelling it will close the request and remove it from the active queue.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Keep request</AlertDialogCancel>
+                        <AlertDialogAction
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          onClick={() => void handleCancelTicket(selectedTicket.id)}
+                        >
+                          Cancel request
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
               </div>
-            );
-          })}
-        </div>
-      )}
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/src/pages/tickets/NewTicket.tsx
+++ b/src/pages/tickets/NewTicket.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
 import { AlertCircle } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { PageHeader } from '@/components/shared/PageHeader';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -32,12 +33,12 @@ import {
   ROLE_CONTEXT,
   ticketSchema,
   AttachmentsSection,
-  CustomFieldsSection,
   RequestDescriptionCard,
   RequestHeaderCard,
   RequestSummaryCard,
   StickySubmitPanel,
   type ApprovalPlanState,
+  type DescriptionSource,
   type TicketFormData,
 } from './new-ticket/NewTicketSections';
 
@@ -56,9 +57,13 @@ export default function NewTicket() {
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, string>>({});
   const [approvalConfirmData, setApprovalConfirmData] = useState<TicketFormData | null>(null);
   const [draftSavedAt, setDraftSavedAt] = useState<Date | null>(null);
+  const [descriptionSource, setDescriptionSource] = useState<DescriptionSource>('subcategory');
   const fileInputRef = useRef<HTMLInputElement>(null);
   const draftRestoredRef = useRef(false);
   const skipDraftSaveRef = useRef(false);
+  // Tracks the last description text we auto-filled from a category/subcategory,
+  // so we only overwrite the body while it still holds that suggested text.
+  const autoFilledDescriptionRef = useRef('');
 
   const roleContext = ROLE_CONTEXT[user?.role as AppRole] ?? DEFAULT_ROLE_CONTEXT;
 
@@ -185,6 +190,35 @@ export default function NewTicket() {
       form.setValue('subcategory', nextSubcategory, { shouldValidate: true });
     }
   }, [availableSubcategories, form]);
+
+  // ── Description auto-fill from category / subcategory description ──────────
+  // Default source is the subcategory's description, falling back to the
+  // category's. We only overwrite the body while it still holds the last
+  // suggested text — manual edits (or a restored draft) are preserved.
+  const selectedCategoryDescription = selectedCategory?.description ?? '';
+  const selectedSubcategoryDescription = selectedSubcategory?.description ?? '';
+
+  useEffect(() => {
+    if (descriptionSource === 'custom') return;
+    const suggested = descriptionSource === 'category'
+      ? selectedCategoryDescription
+      : (selectedSubcategoryDescription || selectedCategoryDescription);
+    const current = form.getValues('description') ?? '';
+    // Respect text the user typed or a restored draft.
+    if (current !== '' && current !== autoFilledDescriptionRef.current) return;
+    if (suggested !== current) {
+      form.setValue('description', suggested, { shouldValidate: true });
+    }
+    autoFilledDescriptionRef.current = suggested;
+  }, [descriptionSource, selectedCategoryDescription, selectedSubcategoryDescription, form]);
+
+  // Once the body diverges from the suggested text, switch to "Custom" so
+  // later category/subcategory changes stop overwriting it.
+  useEffect(() => {
+    if (descriptionSource !== 'custom' && descriptionValue !== autoFilledDescriptionRef.current) {
+      setDescriptionSource('custom');
+    }
+  }, [descriptionValue, descriptionSource]);
 
   const validateAndAddFiles = useCallback(
     (incoming: File[]) => {
@@ -353,6 +387,8 @@ export default function NewTicket() {
       subcategory: firstSubcategoryKey,
     });
     setCustomFieldValues({});
+    autoFilledDescriptionRef.current = '';
+    setDescriptionSource('subcategory');
     if (draftKey) window.localStorage.removeItem(draftKey);
     toast.success('Request submitted', {
       description: 'Your request has been recorded and will be reviewed shortly.',
@@ -434,13 +470,15 @@ export default function NewTicket() {
   return (
     <div className="flex h-full min-h-0 w-full flex-col gap-4 animate-fade-in">
       {/* ── Page header ──────────────────────────────────────── */}
-      <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="min-w-0">
-          <h1 className="text-xl font-semibold tracking-tight text-foreground">
-            {roleContext.pageTitle}
-          </h1>
-          <p className="text-sm text-muted-foreground">{roleContext.pageSubtitle}</p>
-        </div>
+      <div className="shrink-0 [&>div]:mb-0">
+        <PageHeader
+          title={roleContext.pageTitle}
+          description={roleContext.pageSubtitle}
+          breadcrumbs={[
+            { label: 'Internal Requests', path: '/portal' },
+            { label: 'New request' },
+          ]}
+        />
       </div>
 
       {/* ── Error state ──────────────────────────────────────── */}
@@ -482,6 +520,10 @@ export default function NewTicket() {
               onSubcategoryChange={handleSubcategoryChange}
               subjectValue={subjectValue}
               subjectStatus={fieldValidationStatus.subject}
+              customFields={customFields}
+              customFieldValues={customFieldValues}
+              setCustomFieldValues={setCustomFieldValues}
+              companyId={user?.company_id}
             />
 
             <RequestDescriptionCard
@@ -489,14 +531,8 @@ export default function NewTicket() {
               roleContext={roleContext}
               descriptionValue={descriptionValue}
               descriptionStatus={fieldValidationStatus.description}
-            />
-
-            <CustomFieldsSection
-              customFields={customFields}
-              selectedCategory={selectedCategory}
-              customFieldValues={customFieldValues}
-              companyId={user?.company_id}
-              setCustomFieldValues={setCustomFieldValues}
+              descriptionSource={descriptionSource}
+              onDescriptionSourceChange={setDescriptionSource}
             />
           </div>
 

--- a/src/pages/tickets/PortalAnnouncements.tsx
+++ b/src/pages/tickets/PortalAnnouncements.tsx
@@ -7,7 +7,8 @@ import {
 } from 'lucide-react';
 
 import { PageHeader } from '@/components/shared/PageHeader';
-import { Badge } from '@/components/ui/badge';
+import { RequestBadge } from '@/components/tickets/RequestBadge';
+import { type Tone } from '@/lib/statusTones';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -53,17 +54,30 @@ const TYPE_LABELS: Record<PortalAnnouncementType, string> = {
   deadline:       'Deadline',
 };
 
-const PRIORITY_COLORS: Record<PortalAnnouncementPriority, string> = {
-  low:    'bg-gray-100 text-gray-600 border-gray-200',
-  normal: 'bg-blue-50 text-blue-700 border-blue-200',
-  high:   'bg-orange-100 text-orange-700 border-orange-200',
-  urgent: 'bg-red-100 text-red-700 border-red-200',
+const PRIORITY_TONES: Record<PortalAnnouncementPriority, Tone> = {
+  low:    'slate',
+  normal: 'blue',
+  high:   'amber',
+  urgent: 'red',
 };
 
-const STATUS_COLORS: Record<PortalAnnouncementStatus, string> = {
-  draft:     'bg-yellow-50 text-yellow-700 border-yellow-200',
-  published: 'bg-green-50 text-green-700 border-green-200',
-  archived:  'bg-gray-100 text-gray-500 border-gray-200',
+const PRIORITY_LABELS: Record<PortalAnnouncementPriority, string> = {
+  low:    'Low',
+  normal: 'Normal',
+  high:   'High',
+  urgent: 'Urgent',
+};
+
+const STATUS_TONES: Record<PortalAnnouncementStatus, Tone> = {
+  draft:     'amber',
+  published: 'emerald',
+  archived:  'slate',
+};
+
+const STATUS_LABELS: Record<PortalAnnouncementStatus, string> = {
+  draft:     'Draft',
+  published: 'Published',
+  archived:  'Archived',
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -551,21 +565,13 @@ function AnnouncementCard({
                 {record.title}
               </CardTitle>
               <div className="flex gap-1.5 flex-wrap shrink-0">
-                <Badge variant="outline" className={`text-xs ${PRIORITY_COLORS[record.priority]}`}>
-                  {record.priority.charAt(0).toUpperCase() + record.priority.slice(1)}
-                </Badge>
-                <Badge variant="outline" className="text-xs bg-purple-50 text-purple-700 border-purple-200">
-                  {TYPE_LABELS[record.announcement_type]}
-                </Badge>
+                <RequestBadge tone={PRIORITY_TONES[record.priority]} label={PRIORITY_LABELS[record.priority]} />
+                <RequestBadge tone="violet" label={TYPE_LABELS[record.announcement_type]} />
                 {canManage && (
-                  <Badge variant="outline" className={`text-xs ${STATUS_COLORS[record.status]}`}>
-                    {record.status.charAt(0).toUpperCase() + record.status.slice(1)}
-                  </Badge>
+                  <RequestBadge tone={STATUS_TONES[record.status]} label={STATUS_LABELS[record.status]} />
                 )}
                 {expired && (
-                  <Badge variant="outline" className="text-xs bg-gray-100 text-gray-500 border-gray-200">
-                    Expired
-                  </Badge>
+                  <RequestBadge tone="slate" label="Expired" />
                 )}
               </div>
             </div>

--- a/src/pages/tickets/PortalDocuments.tsx
+++ b/src/pages/tickets/PortalDocuments.tsx
@@ -7,7 +7,8 @@ import {
 } from 'lucide-react';
 
 import { PageHeader } from '@/components/shared/PageHeader';
-import { Badge } from '@/components/ui/badge';
+import { RequestBadge } from '@/components/tickets/RequestBadge';
+import { type Tone } from '@/lib/statusTones';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -69,20 +70,26 @@ const CATEGORY_LABELS: Record<PortalDocumentCategory, string> = {
   general:   'General',
 };
 
-const CATEGORY_COLORS: Record<PortalDocumentCategory, string> = {
-  form:      'bg-blue-50 text-blue-700 border-blue-200',
-  template:  'bg-violet-50 text-violet-700 border-violet-200',
-  sop:       'bg-orange-50 text-orange-700 border-orange-200',
-  guideline: 'bg-teal-50 text-teal-700 border-teal-200',
-  checklist: 'bg-green-50 text-green-700 border-green-200',
-  policy:    'bg-red-50 text-red-700 border-red-200',
-  general:   'bg-gray-100 text-gray-600 border-gray-200',
+const CATEGORY_TONES: Record<PortalDocumentCategory, Tone> = {
+  form:      'blue',
+  template:  'violet',
+  sop:       'amber',
+  guideline: 'emerald',
+  checklist: 'emerald',
+  policy:    'red',
+  general:   'slate',
 };
 
-const STATUS_COLORS: Record<PortalDocumentStatus, string> = {
-  active:   'bg-green-50 text-green-700 border-green-200',
-  inactive: 'bg-yellow-50 text-yellow-700 border-yellow-200',
-  archived: 'bg-gray-100 text-gray-500 border-gray-200',
+const STATUS_TONES: Record<PortalDocumentStatus, Tone> = {
+  active:   'emerald',
+  inactive: 'amber',
+  archived: 'slate',
+};
+
+const STATUS_LABELS: Record<PortalDocumentStatus, string> = {
+  active:   'Active',
+  inactive: 'Inactive',
+  archived: 'Archived',
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -302,7 +309,7 @@ export default function PortalDocuments() {
   return (
     <div className="w-full space-y-4">
       <PageHeader
-        title="Documents &amp; Forms"
+        title="Documents & Forms"
         description="Downloadable forms, templates, SOPs, and supporting documents"
         breadcrumbs={[{ label: 'Internal Requests' }, { label: 'Documents & Forms' }]}
         actions={
@@ -642,18 +649,12 @@ function DocumentRow({
           <div className="flex items-center gap-2 flex-wrap">
             {pinned && <Pin className="h-3.5 w-3.5 text-amber-600 shrink-0" />}
             <p className="text-sm font-medium truncate">{record.title}</p>
-            <Badge variant="outline" className={`text-xs shrink-0 ${CATEGORY_COLORS[record.category]}`}>
-              {CATEGORY_LABELS[record.category]}
-            </Badge>
+            <RequestBadge tone={CATEGORY_TONES[record.category]} label={CATEGORY_LABELS[record.category]} className="shrink-0" />
             {canManage && (
-              <Badge variant="outline" className={`text-xs shrink-0 ${STATUS_COLORS[record.status]}`}>
-                {record.status.charAt(0).toUpperCase() + record.status.slice(1)}
-              </Badge>
+              <RequestBadge tone={STATUS_TONES[record.status]} label={STATUS_LABELS[record.status]} className="shrink-0" />
             )}
             {expired && (
-              <Badge variant="outline" className="text-xs shrink-0 bg-gray-100 text-gray-500 border-gray-200">
-                Expired
-              </Badge>
+              <RequestBadge tone="slate" label="Expired" className="shrink-0" />
             )}
           </div>
           <div className="flex items-center gap-3 mt-0.5 flex-wrap text-xs text-muted-foreground">

--- a/src/pages/tickets/RequestHistory.tsx
+++ b/src/pages/tickets/RequestHistory.tsx
@@ -21,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { PageHeader } from '@/components/shared/PageHeader';
 import { RequestDetailPanel } from '@/components/tickets/RequestDetailPanel';
 import {
   Drawer,
@@ -268,16 +269,29 @@ export default function RequestHistory() {
     <div className="flex h-full flex-col gap-4 p-4 lg:p-6">
       {/* Header + filters */}
       <div className="flex flex-col gap-3">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Archive className="h-4 w-4" />
-            <span className="text-sm font-medium">
-              {loading ? '…' : `${totalCount.toLocaleString()} record${totalCount !== 1 ? 's' : ''}`}
-            </span>
-          </div>
-          <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => void loadTickets()} disabled={loading} aria-label="Refresh request history">
-            <RefreshCcw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-          </Button>
+        <div className="[&>div]:mb-0">
+          <PageHeader
+            title="Request History"
+            description="Browse resolved, closed, and cancelled requests."
+            breadcrumbs={[{ label: 'Internal Requests', path: '/portal' }, { label: 'History' }]}
+            actions={
+              <>
+                <span className="text-sm text-muted-foreground">
+                  {loading ? '…' : `${totalCount.toLocaleString()} record${totalCount !== 1 ? 's' : ''}`}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => void loadTickets()}
+                  disabled={loading}
+                >
+                  <RefreshCcw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+                  Refresh
+                </Button>
+              </>
+            }
+          />
         </div>
 
         {/* Search + filters */}

--- a/src/pages/tickets/RequestQueue.tsx
+++ b/src/pages/tickets/RequestQueue.tsx
@@ -1,30 +1,33 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import { formatDistanceToNow } from 'date-fns';
 import {
   AlertCircle,
   AlertTriangle,
   ChevronDown,
-  ChevronLeft,
-  ChevronRight,
   ChevronUp,
   Clock,
   Download,
   Inbox,
-  Loader2,
   RefreshCcw,
   ShieldCheck,
   SlidersHorizontal,
   User,
   UserX,
-  X,
 } from 'lucide-react';
 
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import { PanelErrorBoundary } from '@/components/shared/PanelErrorBoundary';
+import { PageHeader } from '@/components/shared/PageHeader';
+import { HrmsEmptyState } from '@/components/shared/HrmsEmptyState';
+import { StandardTable, type StandardTableColumn } from '@/components/shared/StandardTable';
+import { TableSkeleton } from '@/components/ui/TableSkeleton';
 import { RequestDetailPanel } from '@/components/tickets/RequestDetailPanel';
+import { RequestPriorityBadge, RequestStatusBadge } from '@/components/tickets/RequestBadge';
+import { TicketApprovalSummary } from '@/components/tickets/TicketApprovalSummary';
+import { TicketSlaSummary } from '@/components/tickets/TicketSlaSummary';
 import {
   RequestQueueFilters,
   type AssigneeFilter,
@@ -32,7 +35,6 @@ import {
   type SlaFilter,
   type StatusFilter,
 } from '@/components/tickets/RequestQueueFilters';
-import { RequestQueueList } from '@/components/tickets/RequestQueueList';
 import { RequestQueueMetricGrid } from '@/components/tickets/RequestQueueMetricGrid';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -48,9 +50,12 @@ import { useRequestSubcategories } from '@/hooks/useRequestSubcategories';
 import { useTicketsRealtime } from '@/hooks/useTicketsRealtime';
 import { usePersistedDraftMap } from '@/hooks/usePersistedDraftMap';
 import {
-  Drawer,
-  DrawerContent,
-} from '@/components/ui/drawer';
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 import {
   Dialog,
   DialogContent,
@@ -104,32 +109,12 @@ const priorityOptions: Array<{ value: TicketPriority; label: string }> = [
 
 const REQUEST_QUEUE_PAGE_SIZE = 25;
 
-function useIsLargeScreen() {
-  const [isLargeScreen, setIsLargeScreen] = useState(() => {
-    if (typeof window === 'undefined') return true;
-    return window.matchMedia('(min-width: 1024px)').matches;
-  });
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return undefined;
-
-    const mediaQuery = window.matchMedia('(min-width: 1024px)');
-    const handleChange = () => setIsLargeScreen(mediaQuery.matches);
-    handleChange();
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, []);
-
-  return isLargeScreen;
-}
-
 // formatTicketLabel, isOpenStatus, isApprovalAssignedToUser, csvCell, downloadCsv
 // are now imported from '@/lib/requestFormatters'
 
 export default function RequestQueue() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const isLargeScreen = useIsLargeScreen();
   const { categories } = useRequestCategories(user?.company_id, true);
   const { subcategories } = useRequestSubcategories(user?.company_id, { includeInactive: true });
   const { fields: formFields } = useRequestFormFields(user?.company_id, { includeInactive: true });
@@ -144,7 +129,6 @@ export default function RequestQueue() {
   const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkSaving, setBulkSaving] = useState(false);
-  const [detailDrawerOpen, setDetailDrawerOpen] = useState(false);
   const [metricsExpanded, setMetricsExpanded] = useState(() => {
     if (typeof window === 'undefined') return true;
     return window.localStorage.getItem('requestQueue.metricsExpanded') !== 'false';
@@ -340,10 +324,6 @@ export default function RequestQueue() {
   }, [ticketPage, user]);
 
   useEffect(() => {
-    if (isLargeScreen) setDetailDrawerOpen(false);
-  }, [isLargeScreen]);
-
-  useEffect(() => {
     if (typeof window === 'undefined') return;
     window.localStorage.setItem('requestQueue.metricsExpanded', String(metricsExpanded));
   }, [metricsExpanded]);
@@ -372,21 +352,10 @@ export default function RequestQueue() {
     });
   }, [categories, searchTerm, subcategories, tickets]);
 
-  const selectedTicket = useMemo(() => {
-    return filteredTickets.find((ticket) => ticket.id === selectedTicketId) ?? filteredTickets[0] ?? null;
-  }, [filteredTickets, selectedTicketId]);
-
-  const totalPages = Math.max(1, Math.ceil(totalCount / REQUEST_QUEUE_PAGE_SIZE));
-
-  useEffect(() => {
-    if (!selectedTicket) {
-      setSelectedTicketId(null);
-      return;
-    }
-    if (selectedTicket.id !== selectedTicketId) {
-      setSelectedTicketId(selectedTicket.id);
-    }
-  }, [selectedTicket, selectedTicketId]);
+  const selectedTicket = useMemo(
+    () => filteredTickets.find((ticket) => ticket.id === selectedTicketId) ?? null,
+    [filteredTickets, selectedTicketId],
+  );
 
   const queueMetrics = useMemo(() => ({
     unassigned: tickets.filter((ticket) => isOpenStatus(ticket.status) && !ticket.assigned_to).length,
@@ -764,46 +733,99 @@ export default function RequestQueue() {
     downloadCsv(`internal-requests-selected-${new Date().toISOString().slice(0, 10)}.csv`, rows);
   };
 
-  return (
-    <div className="flex h-full min-h-[720px] w-full flex-col gap-2 overflow-hidden lg:min-h-0">
-      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 rounded-lg border bg-card px-4 py-2.5 shadow-sm">
+  const columns: StandardTableColumn<CompanyTicketRecord>[] = [
+    {
+      key: 'subject',
+      label: 'Request',
+      className: 'min-w-[260px] max-w-[460px]',
+      render: (ticket) => (
         <div className="min-w-0">
-          <h1 className="text-base font-semibold tracking-tight text-foreground">Request Queue</h1>
-          <p className="text-[11px] text-muted-foreground">Triage, assign, and resolve internal requests</p>
+          <p className="truncate font-medium text-foreground">{ticket.subject}</p>
+          <p className="truncate text-xs text-muted-foreground">
+            {ticket.submitted_by_name ?? 'Unknown'} · {getRequestCategoryLabel(ticket.category, categories)}
+            {ticket.subcategory ? ` / ${getRequestSubcategoryLabel(ticket.subcategory, ticket.category, subcategories)}` : ''}
+          </p>
         </div>
-        <div className="flex flex-wrap items-center gap-1.5">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setMetricsExpanded((current) => !current)}
-            className="h-8 gap-1.5 text-xs"
-            aria-expanded={metricsExpanded}
-          >
-            {metricsExpanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
-            Summary
-          </Button>
-          <Button variant="outline" size="sm" onClick={handleExportCsv} className="h-8 gap-1.5 text-xs" disabled={loading || filteredTickets.length === 0}>
-            <Download className="h-3.5 w-3.5" />
-            CSV
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => void refetchTickets()}
-            className="h-8 gap-1.5 text-xs"
-            disabled={ticketsFetching}
-          >
-            <RefreshCcw className={`h-3.5 w-3.5 ${ticketsFetching ? 'animate-spin' : ''}`} />
-            Refresh
-          </Button>
+      ),
+    },
+    {
+      key: 'priority',
+      label: 'Priority',
+      render: (ticket) => <RequestPriorityBadge priority={ticket.priority} />,
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      render: (ticket) => (
+        <div className="flex flex-wrap items-center gap-1">
+          <RequestStatusBadge status={ticket.status} />
+          {ticket.approval_status === 'pending' && <TicketApprovalSummary ticket={ticket} compact />}
         </div>
-      </div>
+      ),
+    },
+    {
+      key: 'sla',
+      label: 'SLA',
+      sortable: false,
+      render: (ticket) => <TicketSlaSummary ticket={ticket} compact />,
+    },
+    {
+      key: 'assigned_to_name',
+      label: 'Owner',
+      render: (ticket) =>
+        ticket.assigned_to_name
+          ? <span className="text-sm text-foreground">{ticket.assigned_to_name}</span>
+          : <span className="text-sm text-muted-foreground">Unassigned</span>,
+    },
+    {
+      key: 'created_at',
+      label: 'Submitted',
+      className: 'text-right',
+      render: (ticket) => (
+        <span className="whitespace-nowrap text-xs text-muted-foreground">
+          {formatDistanceToNow(new Date(ticket.created_at), { addSuffix: true })}
+        </span>
+      ),
+    },
+  ];
 
-      {metricsExpanded && (
-        <div className="shrink-0">
-          <RequestQueueMetricGrid metrics={queueMetrics} />
-        </div>
-      )}
+  return (
+    <div className="flex h-full w-full flex-col gap-4">
+      <PageHeader
+        title="Request Queue"
+        description="Triage, assign, and resolve internal requests"
+        breadcrumbs={[{ label: 'Internal Requests', path: '/portal' }, { label: 'Queue' }]}
+        actions={
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setMetricsExpanded((current) => !current)}
+              className="gap-1.5"
+              aria-expanded={metricsExpanded}
+            >
+              {metricsExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+              Summary
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleExportCsv} className="gap-1.5" disabled={loading || filteredTickets.length === 0}>
+              <Download className="h-4 w-4" />
+              CSV
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void refetchTickets()}
+              className="gap-1.5"
+              disabled={ticketsFetching}
+            >
+              <RefreshCcw className={`h-4 w-4 ${ticketsFetching ? 'animate-spin' : ''}`} />
+              Refresh
+            </Button>
+          </>
+        }
+      />
+
+      {metricsExpanded && <RequestQueueMetricGrid metrics={queueMetrics} />}
 
       {/* Saved views */}
       <div className="flex shrink-0 gap-1 overflow-x-auto pb-0.5">
@@ -828,56 +850,6 @@ export default function RequestQueue() {
         })}
       </div>
 
-      {/* Bulk action toolbar */}
-      {selectedIds.size > 0 && (
-        <div className="flex shrink-0 items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 shadow-sm">
-          <span className="text-xs font-medium text-foreground">{selectedIds.size} selected</span>
-          <div className="h-4 w-px bg-border" />
-          <Select value="" onValueChange={(value) => void handleBulkAssign(value)} disabled={bulkSaving}>
-            <SelectTrigger className="h-7 w-[150px] text-xs">
-              <SelectValue placeholder="Assign to..." />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="unassigned">Unassigned</SelectItem>
-              {assignees.map((assignee) => (
-                <SelectItem key={assignee.id} value={assignee.id}>{assignee.name}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select value="" onValueChange={(value) => void handleBulkStatus(value as TicketStatus)} disabled={bulkSaving}>
-            <SelectTrigger className="h-7 w-[150px] text-xs">
-              <SelectValue placeholder="Set status..." />
-            </SelectTrigger>
-            <SelectContent>
-              {statusOptions.map((status) => (
-                <SelectItem key={status.value} value={status.value}>{status.label}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 gap-1 text-xs"
-            onClick={handleBulkExportCsv}
-            disabled={bulkSaving}
-          >
-            <Download className="h-3 w-3" />
-            CSV
-          </Button>
-          <div className="flex-1" />
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 gap-1 text-xs text-muted-foreground"
-            onClick={() => setSelectedIds(new Set())}
-            disabled={bulkSaving}
-          >
-            <X className="h-3 w-3" />
-            Clear
-          </Button>
-        </div>
-      )}
-
       <div className="shrink-0">
         <RequestQueueFilters
           searchTerm={searchTerm}
@@ -897,140 +869,105 @@ export default function RequestQueue() {
         />
       </div>
 
-      {loading ? (
-        <Card className="flex min-h-0 flex-1">
-          <CardContent className="flex flex-1 items-center justify-center gap-3 py-12 text-muted-foreground">
-            <Loader2 className="h-5 w-5 animate-spin" />
-            <span>Loading the request queue...</span>
-          </CardContent>
-        </Card>
-      ) : error ? (
-        <Card className="flex min-h-0 flex-1">
-          <CardContent className="flex flex-1 flex-col items-center justify-center gap-4 py-12 text-center">
-            <AlertCircle className="h-8 w-8 text-destructive" />
-            <div className="space-y-1">
-              <p className="font-medium text-foreground">Unable to load the request queue</p>
-              <p className="text-sm text-muted-foreground">{error}</p>
-            </div>
-            <Button onClick={() => void refetchTickets()} variant="outline" className="gap-2">
-              <RefreshCcw className="h-4 w-4" />
-              Retry
-            </Button>
-          </CardContent>
-        </Card>
-      ) : filteredTickets.length === 0 ? (
-        <Card className="flex min-h-0 flex-1">
-          <CardContent className="flex flex-1 flex-col items-center justify-center gap-3 py-12 text-center">
-            <ShieldCheck className="h-8 w-8 text-muted-foreground" />
-            <div className="space-y-1">
-              {hasActiveFilters ? (
-                <>
-                  <p className="font-medium text-foreground">No requests match the current filters</p>
-                  <p className="text-sm text-muted-foreground">Try adjusting the filters, or clear them to see all requests.</p>
-                </>
-              ) : (
-                <>
-                  <p className="font-medium text-foreground">No requests in the queue yet</p>
-                  <p className="text-sm text-muted-foreground">New requests will appear here when submitted.</p>
-                </>
-              )}
-            </div>
-            {hasActiveFilters && (
-              <Button variant="outline" size="sm" onClick={handleClearFilters} className="gap-2">
-                <SlidersHorizontal className="h-3.5 w-3.5" />
-                Clear filters
-              </Button>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {loading ? (
+          <TableSkeleton rows={8} cols={6} />
+        ) : error ? (
+          <HrmsEmptyState
+            icon={AlertCircle}
+            title="Unable to load the request queue"
+            description={error}
+            action={{ label: 'Retry', onClick: () => void refetchTickets() }}
+          />
+        ) : filteredTickets.length === 0 ? (
+          <HrmsEmptyState
+            icon={hasActiveFilters ? SlidersHorizontal : ShieldCheck}
+            title={hasActiveFilters ? 'No requests match the current filters' : 'No requests in the queue yet'}
+            description={
+              hasActiveFilters
+                ? 'Try adjusting the filters, or clear them to see all requests.'
+                : 'New requests will appear here when submitted.'
+            }
+            action={hasActiveFilters ? { label: 'Clear filters', onClick: handleClearFilters } : undefined}
+          />
+        ) : (
+          <StandardTable
+            data={filteredTickets}
+            columns={columns}
+            rowKey="id"
+            hideSearch
+            mobileLayout="cards"
+            serverSide
+            totalCount={totalCount}
+            currentPage={page}
+            pageSizes={[REQUEST_QUEUE_PAGE_SIZE]}
+            onPageChange={(next) => {
+              setPage(next);
+              setSelectedIds(new Set());
+            }}
+            selectable
+            selected={selectedIds}
+            onSelectionChange={setSelectedIds}
+            bulkActions={() => (
+              <>
+                <Select value="" onValueChange={(value) => void handleBulkAssign(value)} disabled={bulkSaving}>
+                  <SelectTrigger className="h-7 w-[150px] text-xs">
+                    <SelectValue placeholder="Assign to..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="unassigned">Unassigned</SelectItem>
+                    {assignees.map((assignee) => (
+                      <SelectItem key={assignee.id} value={assignee.id}>{assignee.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Select value="" onValueChange={(value) => void handleBulkStatus(value as TicketStatus)} disabled={bulkSaving}>
+                  <SelectTrigger className="h-7 w-[150px] text-xs">
+                    <SelectValue placeholder="Set status..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {statusOptions.map((status) => (
+                      <SelectItem key={status.value} value={status.value}>{status.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Button variant="outline" size="sm" className="h-7 gap-1 text-xs" onClick={handleBulkExportCsv} disabled={bulkSaving}>
+                  <Download className="h-3 w-3" />
+                  CSV
+                </Button>
+              </>
             )}
-          </CardContent>
-        </Card>
-      ) : selectedTicket ? (
-        <div className="grid min-h-0 flex-1 gap-3 overflow-hidden lg:grid-cols-[minmax(340px,0.9fr)_minmax(560px,1.6fr)] xl:grid-cols-[minmax(380px,0.8fr)_minmax(640px,1.7fr)]">
-          <RequestQueueList
-            tickets={filteredTickets}
-            selectedTicketId={selectedTicket.id}
-            openCount={statusCounts.open}
-            categories={categories}
-            subcategories={subcategories}
-            attachmentsByTicket={attachmentsByTicket}
-            selectedIds={selectedIds}
-            onToggleSelect={(ticketId) =>
-              setSelectedIds((prev) => {
-                const next = new Set(prev);
-                if (next.has(ticketId)) next.delete(ticketId);
-                else next.add(ticketId);
-                return next;
-              })
-            }
-            onToggleSelectAll={(allIds) =>
-              setSelectedIds((prev) => {
-                const allSelected = allIds.every((id) => prev.has(id));
-                if (allSelected) {
-                  const next = new Set(prev);
-                  allIds.forEach((id) => next.delete(id));
-                  return next;
-                }
-                return new Set([...prev, ...allIds]);
-              })
-            }
-            onSelectTicket={(ticketId) => {
-              setSelectedTicketId(ticketId);
-              void handleTicketOpen(ticketId);
-              if (!isLargeScreen) setDetailDrawerOpen(true);
+            onRowClick={(ticket) => {
+              setSelectedTicketId(ticket.id);
+              void handleTicketOpen(ticket.id);
             }}
           />
+        )}
+      </div>
 
-          <section className="hidden min-h-0 overflow-hidden rounded-lg border border-border bg-card shadow-sm lg:block">
-            <PanelErrorBoundary scope="request-queue:detail" resetKey={selectedTicket.id}>
-              {renderDetailPanel(selectedTicket)}
-            </PanelErrorBoundary>
-          </section>
-        </div>
-      ) : null}
-
-      {!loading && !error && totalCount > 0 && (
-        <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 rounded-lg border bg-card px-3 py-1.5 text-xs text-muted-foreground shadow-sm">
-          <span>
-            {((page - 1) * REQUEST_QUEUE_PAGE_SIZE + 1).toLocaleString()}–{Math.min(page * REQUEST_QUEUE_PAGE_SIZE, totalCount).toLocaleString()} of {totalCount.toLocaleString()}
-          </span>
-          <div className="flex items-center gap-1.5">
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1 text-xs"
-              disabled={page <= 1 || ticketsFetching}
-              onClick={() => { setPage((current) => Math.max(1, current - 1)); setSelectedIds(new Set()); }}
-            >
-              <ChevronLeft className="h-3.5 w-3.5" />
-              Prev
-            </Button>
-            <span className="min-w-[70px] text-center text-[11px] text-foreground tabular-nums">
-              {page} / {totalPages}
-            </span>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1 text-xs"
-              disabled={page >= totalPages || ticketsFetching}
-              onClick={() => { setPage((current) => Math.min(totalPages, current + 1)); setSelectedIds(new Set()); }}
-            >
-              Next
-              <ChevronRight className="h-3.5 w-3.5" />
-            </Button>
-          </div>
-        </div>
-      )}
-
-      <Drawer open={!isLargeScreen && detailDrawerOpen && !!selectedTicket} onOpenChange={setDetailDrawerOpen}>
-        <DrawerContent className="max-h-[92vh]">
+      {/* Request detail drawer */}
+      <Sheet
+        open={!!selectedTicket}
+        onOpenChange={(open) => {
+          if (!open) setSelectedTicketId(null);
+        }}
+      >
+        <SheetContent side="right" className="w-full gap-0 overflow-y-auto p-0 sm:max-w-2xl">
           {selectedTicket && (
-            <div className="overflow-y-auto px-4 pb-6 pt-3">
-              <PanelErrorBoundary scope="request-queue:detail-drawer" resetKey={selectedTicket.id}>
-                {renderDetailPanel(selectedTicket, 'drawer')}
-              </PanelErrorBoundary>
-            </div>
+            <>
+              <SheetHeader className="sr-only">
+                <SheetTitle>{selectedTicket.subject}</SheetTitle>
+                <SheetDescription>Internal request detail</SheetDescription>
+              </SheetHeader>
+              <div className="px-4 py-4">
+                <PanelErrorBoundary scope="request-queue:detail" resetKey={selectedTicket.id}>
+                  {renderDetailPanel(selectedTicket, 'drawer')}
+                </PanelErrorBoundary>
+              </div>
+            </>
           )}
-        </DrawerContent>
-      </Drawer>
+        </SheetContent>
+      </Sheet>
 
       <Dialog open={!!reviewTarget} onOpenChange={(open) => {
         if (!open) {

--- a/src/pages/tickets/RequestSetup.tsx
+++ b/src/pages/tickets/RequestSetup.tsx
@@ -4,6 +4,8 @@ import { Route, Settings2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { PageHeader } from '@/components/shared/PageHeader';
+import { MetricCard } from '@/components/shared/MetricCard';
 import { useAuth } from '@/contexts/AuthContext';
 
 import { AttachmentSettingsEditor } from './request-setup/AttachmentSettingsEditor';
@@ -55,30 +57,18 @@ export default function RequestSetup() {
 
   return (
     <div className="w-full space-y-4">
-      <div className="rounded-lg border bg-card px-4 py-3 shadow-sm">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">Internal Requests</p>
-            <h1 className="mt-1 text-xl font-semibold tracking-tight text-foreground">Request Operations Setup</h1>
-            <p className="mt-1 max-w-3xl text-sm leading-5 text-muted-foreground">
-              Shape the requester experience, routing logic, and attachment controls from one workspace.
-            </p>
-          </div>
-          <div className="grid w-full grid-cols-2 gap-2 text-center sm:w-auto sm:min-w-[460px] sm:grid-cols-3">
-            <div className="rounded-lg border bg-background px-3 py-2">
-              <p className="text-lg font-semibold tabular-nums text-foreground">{activeCounts.categories}</p>
-              <p className="text-[11px] text-muted-foreground">Categories</p>
-            </div>
-            <div className="rounded-lg border bg-background px-3 py-2">
-              <p className="text-lg font-semibold tabular-nums text-foreground">{activeCounts.fields}</p>
-              <p className="text-[11px] text-muted-foreground">Fields</p>
-            </div>
-            <div className="rounded-lg border bg-background px-3 py-2">
-              <p className="text-lg font-semibold tabular-nums text-foreground">{activeCounts.rules}</p>
-              <p className="text-[11px] text-muted-foreground">Rules</p>
-            </div>
-          </div>
-        </div>
+      <div className="[&>div]:mb-0">
+        <PageHeader
+          title="Request Operations Setup"
+          description="Shape the requester experience, routing logic, and attachment controls from one workspace."
+          breadcrumbs={[{ label: 'Internal Requests', path: '/portal' }, { label: 'Setup' }]}
+        />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <MetricCard label="Categories" value={activeCounts.categories} tone="blue" />
+        <MetricCard label="Fields" value={activeCounts.fields} tone="violet" />
+        <MetricCard label="Routing rules" value={activeCounts.rules} tone="emerald" />
       </div>
 
       <Card className="overflow-hidden shadow-sm">

--- a/src/pages/tickets/new-ticket/NewTicketSections.tsx
+++ b/src/pages/tickets/new-ticket/NewTicketSections.tsx
@@ -4,6 +4,7 @@ import type { UseFormReturn } from 'react-hook-form';
 import { z } from 'zod';
 import {
   AlertCircle,
+  AlignLeft,
   Check,
   CheckCircle2,
   ChevronRight,
@@ -43,6 +44,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
+import { SectionCard } from '@/components/shared/SectionCard';
 import {
   type InternalRequestApprovalPlan,
   listRequestFieldOptions,
@@ -636,6 +638,11 @@ interface RequestHeaderCardProps {
   onSubcategoryChange: (subcategoryKey: string) => void;
   subjectValue: string;
   subjectStatus: 'valid' | 'invalid' | 'untouched';
+  /** Per-category custom fields, rendered as "Additional information" inside this card. */
+  customFields: RequestFormFieldRecord[];
+  customFieldValues: Record<string, string>;
+  setCustomFieldValues: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  companyId?: string;
 }
 
 export function RequestHeaderCard({
@@ -653,91 +660,82 @@ export function RequestHeaderCard({
   onSubcategoryChange,
   subjectValue,
   subjectStatus,
+  customFields,
+  customFieldValues,
+  setCustomFieldValues,
+  companyId,
 }: RequestHeaderCardProps) {
   return (
-    <Card className="border-border/80 shadow-sm">
-      <CardHeader className="border-b bg-muted/20 px-5 py-4">
-        <p className="text-sm font-semibold text-foreground">Request Details</p>
-      </CardHeader>
-      <CardContent className="space-y-5 p-5">
+    <SectionCard title="Request details" icon={FileText} bodyClassName="space-y-5">
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <Label htmlFor="subject">
+            Request title <span className="text-destructive">*</span>
+          </Label>
+          {subjectStatus === 'valid' && (
+            <CheckCircle2 className="h-4 w-4 text-success" />
+          )}
+          {subjectStatus === 'invalid' && (
+            <XCircle className="h-4 w-4 text-destructive" />
+          )}
+        </div>
+        <Input
+          id="subject"
+          placeholder="e.g. Urgent invoice correction for customer delivery"
+          {...form.register('subject')}
+          className={cn(
+            'h-10 transition-colors',
+            subjectStatus === 'valid' && 'border-success/50 focus-visible:ring-success/50',
+            subjectStatus === 'invalid' && 'border-destructive',
+          )}
+        />
+        {form.formState.errors.subject ? (
+          <p className="flex items-center gap-1 text-xs text-destructive">
+            <AlertCircle className="h-3 w-3" />
+            {form.formState.errors.subject.message}
+          </p>
+        ) : subjectValue.length > 0 ? (
+          <p className="text-xs text-muted-foreground">
+            {subjectValue.length} character{subjectValue.length !== 1 ? 's' : ''}
+          </p>
+        ) : null}
+      </div>
+
+      {/* Category + Subcategory dropdowns */}
+      <div className={cn('grid gap-4', requiresSubcategory && 'md:grid-cols-2')}>
         <div className="space-y-1.5">
-          <div className="flex items-center justify-between gap-2">
-            <Label htmlFor="subject">
-              Request Title <span className="text-destructive">*</span>
-            </Label>
-            {subjectStatus === 'valid' && (
-              <CheckCircle2 className="h-4 w-4 text-success" />
-            )}
-            {subjectStatus === 'invalid' && (
-              <XCircle className="h-4 w-4 text-destructive" />
-            )}
-          </div>
-          <Input
-            id="subject"
-            placeholder="e.g. Urgent invoice correction for customer delivery"
-            {...form.register('subject')}
-            className={cn(
-              'h-10 transition-colors',
-              subjectStatus === 'valid' && 'border-success/50 focus-visible:ring-success/50',
-              subjectStatus === 'invalid' && 'border-destructive',
-            )}
-          />
-          {form.formState.errors.subject ? (
+          <Label htmlFor="category">
+            Category <span className="text-destructive">*</span>
+          </Label>
+          <Select value={selectedCategoryKey} onValueChange={onCategoryChange} disabled={categorySelectionDisabled}>
+            <SelectTrigger
+              id="category"
+              className={cn(
+                'h-10',
+                form.formState.errors.category && 'border-destructive',
+                !form.formState.errors.category && form.formState.touchedFields.category && 'border-success/50',
+              )}
+            >
+              <SelectValue placeholder={categoriesLoading ? 'Loading categories...' : 'Select a category'} />
+            </SelectTrigger>
+            <SelectContent>
+              {categories.map(({ key, label }) => (
+                <SelectItem key={key} value={key}>{label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {form.formState.errors.category && (
             <p className="flex items-center gap-1 text-xs text-destructive">
               <AlertCircle className="h-3 w-3" />
-              {form.formState.errors.subject.message}
+              {form.formState.errors.category.message}
             </p>
-          ) : subjectValue.length > 0 ? (
-            <p className="text-xs text-muted-foreground">
-              {subjectValue.length} character{subjectValue.length !== 1 ? 's' : ''}
-            </p>
-          ) : null}
+          )}
         </div>
 
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="space-y-1.5">
-            <Label htmlFor="category">
-              Category <span className="text-destructive">*</span>
-            </Label>
-            <Select
-              value={selectedCategoryKey}
-              onValueChange={onCategoryChange}
-              disabled={categorySelectionDisabled}
-            >
-              <SelectTrigger
-                id="category"
-                className={cn(
-                  'h-10',
-                  form.formState.errors.category ? 'border-destructive' : '',
-                  !form.formState.errors.category && form.formState.touchedFields.category && 'border-success/50',
-                )}
-              >
-                <SelectValue
-                  placeholder={
-                    categoriesLoading ? 'Loading categories...' : 'Select a category'
-                  }
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {categories.map(({ key, label }) => (
-                  <SelectItem key={key} value={key}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {form.formState.errors.category && (
-              <p className="flex items-center gap-1 text-xs text-destructive">
-                <AlertCircle className="h-3 w-3" />
-                {form.formState.errors.category.message}
-              </p>
-            )}
-          </div>
-
+        {requiresSubcategory && (
           <div className="space-y-1.5">
             <Label htmlFor="subcategory">
-              Subcategory
-              {requiresSubcategory && <span className="text-destructive"> *</span>}
+              Subcategory <span className="text-destructive">*</span>
             </Label>
             <Select
               value={selectedSubcategoryKey}
@@ -748,25 +746,15 @@ export function RequestHeaderCard({
                 id="subcategory"
                 className={cn(
                   'h-10',
-                  form.formState.errors.subcategory ? 'border-destructive' : '',
+                  form.formState.errors.subcategory && 'border-destructive',
                   !form.formState.errors.subcategory && form.formState.touchedFields.subcategory && 'border-success/50',
                 )}
               >
-                <SelectValue
-                  placeholder={
-                    subcategoriesLoading
-                      ? 'Loading subcategories...'
-                      : availableSubcategories.length === 0
-                        ? 'No subcategories for this category'
-                        : 'Select a subcategory'
-                  }
-                />
+                <SelectValue placeholder={subcategoriesLoading ? 'Loading subcategories...' : 'Select a subcategory'} />
               </SelectTrigger>
               <SelectContent>
                 {availableSubcategories.map(({ key, label }) => (
-                  <SelectItem key={key} value={key}>
-                    {label}
-                  </SelectItem>
+                  <SelectItem key={key} value={key}>{label}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -782,17 +770,90 @@ export function RequestHeaderCard({
               </p>
             ) : null}
           </div>
+        )}
+      </div>
+
+      {/* Additional information — per-category custom fields */}
+      {customFields.length > 0 && (
+        <div className="space-y-3 border-t border-border pt-4">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm font-semibold text-foreground">Additional information</p>
+            <Badge variant="secondary" className="shrink-0">
+              {customFields.length} field{customFields.length === 1 ? '' : 's'}
+            </Badge>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {customFields.map((field) => {
+              const inputId = `cf-${field.key}`;
+              const value = customFieldValues[field.key] ?? '';
+              const hasValue = value.trim().length > 0;
+              const updateValue = (nextValue: string) => {
+                setCustomFieldValues((prev) => ({ ...prev, [field.key]: nextValue }));
+              };
+              return (
+                <div
+                  key={field.id}
+                  className={cn('space-y-1.5', field.field_type === 'textarea' && 'sm:col-span-2')}
+                >
+                  <Label htmlFor={inputId}>
+                    {field.label}
+                    {field.is_required && <span className="text-destructive"> *</span>}
+                  </Label>
+                  {field.field_type === 'textarea' ? (
+                    <Textarea
+                      id={inputId}
+                      value={value}
+                      onChange={(event) => updateValue(event.target.value)}
+                      placeholder={field.placeholder}
+                      rows={3}
+                      className={cn(field.is_required && hasValue && 'border-success/50')}
+                    />
+                  ) : field.field_type === 'database_select' ? (
+                    <DatabaseFieldSelect
+                      companyId={companyId}
+                      field={field}
+                      value={value}
+                      inputId={inputId}
+                      onChange={updateValue}
+                    />
+                  ) : (
+                    <Input
+                      id={inputId}
+                      type={
+                        field.field_type === 'number'
+                          ? 'number'
+                          : field.field_type === 'date'
+                            ? 'date'
+                            : 'text'
+                      }
+                      value={value}
+                      onChange={(event) => updateValue(event.target.value)}
+                      placeholder={field.placeholder}
+                      className={cn(field.is_required && hasValue && 'border-success/50')}
+                    />
+                  )}
+                  {field.help_text && (
+                    <p className="text-xs text-muted-foreground">{field.help_text}</p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
-      </CardContent>
-    </Card>
+      )}
+    </SectionCard>
   );
 }
+
+export type DescriptionSource = 'subcategory' | 'category' | 'custom';
 
 interface RequestDescriptionCardProps {
   form: UseFormReturn<TicketFormData>;
   roleContext: RoleContext;
   descriptionValue: string;
   descriptionStatus: 'valid' | 'invalid' | 'untouched';
+  descriptionSource: DescriptionSource;
+  onDescriptionSourceChange: (source: DescriptionSource) => void;
 }
 
 export function RequestDescriptionCard({
@@ -800,52 +861,66 @@ export function RequestDescriptionCard({
   roleContext,
   descriptionValue,
   descriptionStatus,
+  descriptionSource,
+  onDescriptionSourceChange,
 }: RequestDescriptionCardProps) {
   return (
-    <Card className="border-border/80 shadow-sm">
-      <CardHeader className="border-b bg-muted/20 px-5 py-4">
-        <p className="text-sm font-semibold text-foreground">
-          Contents / Description <span className="text-destructive">*</span>
-        </p>
-      </CardHeader>
-      <CardContent className="p-5">
-        <div className="space-y-1.5">
-          <div className="flex items-center justify-end gap-2">
-            <span
-              className={cn(
-                'flex items-center gap-1 text-xs tabular-nums transition-colors',
-                descriptionStatus === 'valid'
-                  ? 'text-success'
-                  : descriptionStatus === 'invalid'
-                    ? 'text-destructive'
-                    : 'text-muted-foreground',
-              )}
-            >
-              {descriptionStatus === 'valid' && <CheckCircle2 className="h-3 w-3" />}
-              {descriptionValue.length} / 20 min
-            </span>
-          </div>
-          <Textarea
-            id="description"
-            aria-label="Contents / Description"
-            placeholder={roleContext.descriptionPlaceholder}
-            rows={14}
-            {...form.register('description')}
-            className={cn(
-              'min-h-[320px] resize-y transition-colors',
-              descriptionStatus === 'valid' && 'border-success/50 focus-visible:ring-success/50',
-              descriptionStatus === 'invalid' && 'border-destructive',
-            )}
-          />
-          {form.formState.errors.description && (
-            <p className="flex items-center gap-1 text-xs text-destructive">
-              <AlertCircle className="h-3 w-3" />
-              {form.formState.errors.description.message}
-            </p>
-          )}
+    <SectionCard
+      title="Description"
+      icon={AlignLeft}
+      bodyClassName="space-y-1.5"
+      headerRight={
+        <div className="flex items-center gap-1.5">
+          <span className="hidden text-xs text-muted-foreground sm:inline">Source</span>
+          <Select value={descriptionSource} onValueChange={(value) => onDescriptionSourceChange(value as DescriptionSource)}>
+            <SelectTrigger className="h-7 w-[150px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="subcategory">From subcategory</SelectItem>
+              <SelectItem value="category">From category</SelectItem>
+              <SelectItem value="custom">Custom</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
-      </CardContent>
-    </Card>
+      }
+    >
+      <Textarea
+        id="description"
+        aria-label="Description"
+        placeholder={roleContext.descriptionPlaceholder}
+        rows={14}
+        {...form.register('description')}
+        className={cn(
+          'min-h-[320px] resize-y transition-colors',
+          descriptionStatus === 'valid' && 'border-success/50 focus-visible:ring-success/50',
+          descriptionStatus === 'invalid' && 'border-destructive',
+        )}
+      />
+      <div className="flex items-start justify-between gap-2">
+        {form.formState.errors.description ? (
+          <p className="flex items-center gap-1 text-xs text-destructive">
+            <AlertCircle className="h-3 w-3" />
+            {form.formState.errors.description.message}
+          </p>
+        ) : (
+          <span />
+        )}
+        <span
+          className={cn(
+            'flex shrink-0 items-center gap-1 text-xs tabular-nums transition-colors',
+            descriptionStatus === 'valid'
+              ? 'text-success'
+              : descriptionStatus === 'invalid'
+                ? 'text-destructive'
+                : 'text-muted-foreground',
+          )}
+        >
+          {descriptionStatus === 'valid' && <CheckCircle2 className="h-3 w-3" />}
+          {descriptionValue.length} / 20 chars min
+        </span>
+      </div>
+    </SectionCard>
   );
 }
 
@@ -1045,26 +1120,21 @@ export function RequestSummaryCard({
   requestorName,
 }: RequestSummaryCardProps) {
   return (
-    <div className="rounded-lg border bg-card p-4 shadow-sm">
-      <p className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-        Request Summary
-      </p>
-      <div className="space-y-2.5 text-sm">
-        <div className="flex items-start justify-between gap-3">
-          <span className="shrink-0 text-muted-foreground">Title</span>
-          <span className="min-w-0 text-right font-medium text-foreground">
-            {title.trim() || 'Untitled request'}
-          </span>
-        </div>
-        <Separator />
-        <div className="flex items-start justify-between gap-3">
-          <span className="shrink-0 text-muted-foreground">Requestor</span>
-          <span className="min-w-0 text-right font-medium text-foreground">
-            {requestorName}
-          </span>
-        </div>
+    <SectionCard title="Request summary" icon={FileText} bodyClassName="space-y-2.5 text-sm">
+      <div className="flex items-start justify-between gap-3">
+        <span className="shrink-0 text-muted-foreground">Title</span>
+        <span className="min-w-0 text-right font-medium text-foreground">
+          {title.trim() || 'Untitled request'}
+        </span>
       </div>
-    </div>
+      <Separator />
+      <div className="flex items-start justify-between gap-3">
+        <span className="shrink-0 text-muted-foreground">Requestor</span>
+        <span className="min-w-0 text-right font-medium text-foreground">
+          {requestorName}
+        </span>
+      </div>
+    </SectionCard>
   );
 }
 
@@ -1477,25 +1547,17 @@ export function CustomFieldsSection({
   if (customFields.length === 0) return null;
 
   return (
-    <Card className="shadow-sm">
-      <CardHeader className="border-b bg-muted/20 px-4 py-3">
-        <div className="flex items-center justify-between gap-2">
-          <div>
-            <p className="text-sm font-semibold text-foreground">
-              Additional information
-            </p>
-            <p className="text-xs text-muted-foreground">
-              Extra details required for{' '}
-              {selectedCategory?.label.toLowerCase() ?? 'this category'} requests.
-            </p>
-          </div>
-          <Badge variant="secondary" className="shrink-0">
-            {customFields.length} field{customFields.length === 1 ? '' : 's'}
-          </Badge>
-        </div>
-      </CardHeader>
-      <CardContent className="p-4">
-        <div className="grid gap-4 sm:grid-cols-2">
+    <SectionCard
+      title="Additional information"
+      description={`Extra details for ${selectedCategory?.label.toLowerCase() ?? 'this category'} requests`}
+      icon={Info}
+      headerRight={
+        <Badge variant="secondary" className="shrink-0">
+          {customFields.length} field{customFields.length === 1 ? '' : 's'}
+        </Badge>
+      }
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
           {customFields.map((field) => {
             const inputId = `cf-${field.key}`;
             const value = customFieldValues[field.key] ?? '';
@@ -1561,8 +1623,7 @@ export function CustomFieldsSection({
             );
           })}
         </div>
-      </CardContent>
-    </Card>
+    </SectionCard>
   );
 }
 
@@ -1597,33 +1658,24 @@ export function AttachmentsSection({
   const isLimitReached = attachedFiles.length >= attachmentSettings.max_files_per_ticket;
 
   return (
-    <Card className="shadow-sm">
-      <CardHeader className="border-b bg-muted/20 px-4 py-3">
-        <div className="flex items-center justify-between gap-2">
-          <div>
-            <p className="text-sm font-semibold text-foreground">
-              Attachments
-              <span className="ml-1 text-xs font-normal text-muted-foreground">
-                (optional)
-              </span>
-            </p>
-            <p className="text-xs text-muted-foreground">
-              PDF, Word, Excel, images, CSV, TXT
-            </p>
-          </div>
-          <span
-            className={cn(
-              'shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium tabular-nums',
-              attachedFiles.length > 0
-                ? 'border-primary/30 bg-primary/5 text-primary'
-                : 'border-border bg-muted/40 text-muted-foreground',
-            )}
-          >
-            {attachedFiles.length} / {attachmentSettings.max_files_per_ticket}
-          </span>
-        </div>
-      </CardHeader>
-      <CardContent className={cn('space-y-3', compact ? 'p-3' : 'p-4')}>
+    <SectionCard
+      title="Attachments"
+      description="Optional — PDF, Word, Excel, images, CSV, TXT"
+      icon={Paperclip}
+      bodyClassName={cn('space-y-3', compact && 'p-3')}
+      headerRight={
+        <span
+          className={cn(
+            'shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium tabular-nums',
+            attachedFiles.length > 0
+              ? 'border-primary/30 bg-primary/5 text-primary'
+              : 'border-border bg-muted/40 text-muted-foreground',
+          )}
+        >
+          {attachedFiles.length} / {attachmentSettings.max_files_per_ticket}
+        </span>
+      }
+    >
         <div
           role="button"
           tabIndex={0}
@@ -1692,7 +1744,7 @@ export function AttachmentsSection({
                   <p className="truncate text-xs font-medium text-foreground">
                     {file.name}
                   </p>
-                  <div className="mt-0.5 flex items-center gap-2 text-[10px] text-muted-foreground">
+                  <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
                     <span className="tabular-nums">{formatBytes(file.size)}</span>
                     <span aria-hidden="true">·</span>
                     <span className={cn(uploading ? 'text-primary' : 'text-success')}>
@@ -1727,8 +1779,7 @@ export function AttachmentsSection({
             ))}
           </div>
         )}
-      </CardContent>
-    </Card>
+    </SectionCard>
   );
 }
 

--- a/src/pages/tickets/request-setup/AttachmentSettingsEditor.tsx
+++ b/src/pages/tickets/request-setup/AttachmentSettingsEditor.tsx
@@ -3,6 +3,7 @@ import { Loader2, Save } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAttachmentSettings } from '@/hooks/useAttachmentSettings';
 
@@ -65,7 +66,7 @@ export function AttachmentSettingsEditor({ companyId, actorId }: Props) {
           <div className="space-y-2">
             <Label htmlFor="attach-max-size">Maximum file size per attachment (MB)</Label>
             <div className="flex items-center gap-3">
-              <input
+              <Input
                 id="attach-max-size"
                 type="number"
                 min={1}
@@ -76,7 +77,7 @@ export function AttachmentSettingsEditor({ companyId, actorId }: Props) {
                     Math.min(50, Math.max(1, Number.parseInt(event.target.value, 10) || 1)),
                   )
                 }
-                className="flex h-9 w-24 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="h-9 w-24"
               />
               <span className="text-sm text-muted-foreground">MB (1 – 50)</span>
             </div>
@@ -88,7 +89,7 @@ export function AttachmentSettingsEditor({ companyId, actorId }: Props) {
           <div className="space-y-2">
             <Label htmlFor="attach-max-files">Maximum files per request</Label>
             <div className="flex items-center gap-3">
-              <input
+              <Input
                 id="attach-max-files"
                 type="number"
                 min={1}
@@ -99,7 +100,7 @@ export function AttachmentSettingsEditor({ companyId, actorId }: Props) {
                     Math.min(10, Math.max(1, Number.parseInt(event.target.value, 10) || 1)),
                   )
                 }
-                className="flex h-9 w-24 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="h-9 w-24"
               />
               <span className="text-sm text-muted-foreground">files (1 – 10)</span>
             </div>

--- a/src/pages/tickets/request-setup/CategoryEditor.tsx
+++ b/src/pages/tickets/request-setup/CategoryEditor.tsx
@@ -3,8 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { STALE } from '@/lib/queryClient';
 import {
   AlertCircle,
-  ArrowDown,
-  ArrowUp,
   Loader2,
   Plus,
   Save,
@@ -24,13 +22,15 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { HrmsEmptyState } from '@/components/shared/HrmsEmptyState';
+import { SortableList } from '@/components/ui/SortableList';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -49,13 +49,14 @@ import { useRequestSubcategories } from '@/hooks/useRequestSubcategories';
 import {
   createRequestCategory,
   deleteRequestCategory,
-  moveRequestCategory,
+  reorderRequestCategories,
   updateRequestCategory,
   type RequestCategoryRecord,
 } from '@/services/requestCategoryService';
 import {
   createRequestSubcategory,
-  moveRequestSubcategory,
+  deleteRequestSubcategory,
+  reorderRequestSubcategories,
   updateRequestSubcategory,
   type RequestSubcategoryRecord,
 } from '@/services/requestSubcategoryService';
@@ -116,8 +117,17 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
 
   const [creatingSubcategoryKey, setCreatingSubcategoryKey] = useState<string | null>(null);
   const [busySubcategoryId, setBusySubcategoryId] = useState<string | null>(null);
+  const [deletingSubcategory, setDeletingSubcategory] = useState<RequestSubcategoryRecord | null>(null);
   const [subcategoryDrafts, setSubcategoryDrafts] = useState<Record<string, SubcategoryDraft>>({});
   const [createSubcategoryDrafts, setCreateSubcategoryDrafts] = useState<Record<string, CreateSubcategoryDraft>>({});
+
+  // Local mirrors so drag-and-drop can reorder optimistically; re-synced from
+  // the hooks' server state on every load/reload.
+  const [orderedCategories, setOrderedCategories] = useState<RequestCategoryRecord[]>(categories);
+  const [orderedSubcategories, setOrderedSubcategories] = useState<RequestSubcategoryRecord[]>(subcategories);
+  const [reordering, setReordering] = useState(false);
+  useEffect(() => { setOrderedCategories(categories); }, [categories]);
+  useEffect(() => { setOrderedSubcategories(subcategories); }, [subcategories]);
 
   useEffect(() => {
     setDrafts(Object.fromEntries(categories.map((category) => [category.id, {
@@ -160,7 +170,9 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
     () => categories.find((c) => c.id === editCategoryId) ?? null,
     [categories, editCategoryId],
   );
-  const editCatSubcategories = editCategory ? (subcategoriesByCategory[editCategory.key] ?? []) : [];
+  const editCatSubcategories = editCategory
+    ? orderedSubcategories.filter((sub) => sub.category_key === editCategory.key)
+    : [];
   const editCreateSubDraft = editCategory
     ? (createSubcategoryDrafts[editCategory.key] ?? { label: '', description: '' })
     : { label: '', description: '' };
@@ -275,12 +287,15 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
     setBusyCategoryId(null);
   };
 
-  const handleMove = async (categoryId: string, direction: 'up' | 'down') => {
-    setBusyCategoryId(categoryId);
-    const result = await moveRequestCategory(categoryId, direction, { actorId, companyId });
+  const handleReorderCategories = async (orderedIds: string[]) => {
+    const byId = new Map(orderedCategories.map((category) => [category.id, category]));
+    const next = orderedIds.map((id) => byId.get(id)).filter((c): c is RequestCategoryRecord => Boolean(c));
+    setOrderedCategories(next);
+    setReordering(true);
+    const result = await reorderRequestCategories(orderedIds, { actorId, companyId });
     if (result.error) toast.error('Unable to reorder categories', { description: result.error });
-    else await reload();
-    setBusyCategoryId(null);
+    await reload();
+    setReordering(false);
   };
 
   const handleDeleteCategory = async () => {
@@ -361,26 +376,53 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
     setBusySubcategoryId(null);
   };
 
-  const handleMoveSubcategory = async (subId: string, direction: 'up' | 'down') => {
-    setBusySubcategoryId(subId);
-    const result = await moveRequestSubcategory(subId, direction, { actorId, companyId });
+  const handleReorderSubcategories = async (categoryKey: string, orderedIds: string[]) => {
+    // Optimistically reorder just this category's slice within the flat mirror.
+    setOrderedSubcategories((prev) => {
+      const byId = new Map(prev.filter((s) => s.category_key === categoryKey).map((s) => [s.id, s]));
+      const reordered = orderedIds.map((id) => byId.get(id)).filter((s): s is RequestSubcategoryRecord => Boolean(s));
+      let cursor = 0;
+      return prev.map((sub) => (sub.category_key === categoryKey ? reordered[cursor++] ?? sub : sub));
+    });
+    setReordering(true);
+    const result = await reorderRequestSubcategories(categoryKey, orderedIds, { actorId, companyId });
     if (result.error) toast.error('Unable to reorder subcategories', { description: result.error });
-    else await reloadSubcategories();
+    await reloadSubcategories();
+    setReordering(false);
+  };
+
+  const handleDeleteSubcategory = async (sub: RequestSubcategoryRecord) => {
+    setBusySubcategoryId(sub.id);
+    const result = await deleteRequestSubcategory(sub.id, { actorId, companyId }, sub.updated_at);
     setBusySubcategoryId(null);
+    setDeletingSubcategory(null);
+    if (isConflict(result)) {
+      toast.error('Subcategory changed', { description: CONFLICT_RELOAD_MESSAGE });
+      await reloadSubcategories();
+    } else if (result.error) {
+      if (result.inUse) {
+        toast.warning('Cannot delete — subcategory is in use', { description: result.error });
+      } else {
+        toast.error('Failed to delete subcategory', { description: result.error });
+      }
+    } else {
+      toast.success('Subcategory deleted');
+      await reloadSubcategories();
+    }
   };
 
   return (
     <div className="space-y-4">
-      {/* Create category dialog */}
-      <Dialog open={isAdding} onOpenChange={(open) => {
+      {/* Create category drawer */}
+      <Sheet open={isAdding} onOpenChange={(open) => {
         if (!open && !creating) { setIsAdding(false); setCreateLabel(''); setCreateDescription(''); }
       }}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>New category</DialogTitle>
-            <DialogDescription>Add a new request category for your team.</DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4 py-2">
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-lg">
+          <SheetHeader>
+            <SheetTitle>New category</SheetTitle>
+            <SheetDescription>Add a new request category for your team.</SheetDescription>
+          </SheetHeader>
+          <div className="mt-4 space-y-4">
             <div className="space-y-2">
               <Label htmlFor="request-category-name">Name <span className="text-destructive">*</span></Label>
               <Input
@@ -405,7 +447,7 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
               />
             </div>
           </div>
-          <DialogFooter>
+          <SheetFooter className="mt-4 gap-2">
             <Button
               variant="outline"
               onClick={() => { setIsAdding(false); setCreateLabel(''); setCreateDescription(''); }}
@@ -421,21 +463,21 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
               {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
               Add category
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
 
-      {/* Edit category dialog */}
-      <Dialog open={editCategoryId !== null} onOpenChange={(open) => {
+      {/* Edit category drawer */}
+      <Sheet open={editCategoryId !== null} onOpenChange={(open) => {
         if (!open && !busyCategoryId) setEditCategoryId(null);
       }}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Edit category</DialogTitle>
-            <DialogDescription>Update this category's details, SLA targets, and subcategories.</DialogDescription>
-          </DialogHeader>
+        <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-2xl">
+          <SheetHeader>
+            <SheetTitle>Edit category</SheetTitle>
+            <SheetDescription>Update this category's details, SLA targets, and subcategories.</SheetDescription>
+          </SheetHeader>
           {editCategory && (
-            <div className="max-h-[68vh] space-y-4 overflow-y-auto py-2 pr-1">
+            <div className="mt-4 space-y-4">
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
                   <Label>Name</Label>
@@ -569,20 +611,23 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
                 {editCatSubcategories.length === 0 ? (
                   <p className="text-xs text-muted-foreground">No subcategories yet.</p>
                 ) : (
-                  <div className="space-y-1.5">
-                    {editCatSubcategories.map((sub, subIdx) => {
+                  <SortableList
+                    items={editCatSubcategories}
+                    getId={(sub) => sub.id}
+                    onReorder={(ids) => void handleReorderSubcategories(editCategory.key, ids)}
+                    disabled={reordering}
+                    className="space-y-1.5"
+                  >
+                    {(sub, { handle }) => {
                       const subDraft = subcategoryDrafts[sub.id];
                       const isSubBusy = busySubcategoryId === sub.id;
                       const isSubDirty = hasSubcategoryChanges(sub, subDraft);
                       const subFlowValue = subDraft?.approval_flow_id ?? sub.approval_flow_id ?? '__none__';
                       return (
-                        <div
-                          key={sub.id}
-                          className="space-y-2 rounded-lg border bg-background px-3 py-2.5"
-                        >
+                        <div className="space-y-2 rounded-lg border bg-background px-3 py-2.5">
                           <div className="flex items-center justify-between gap-2">
-                            <div className="flex min-w-0 items-center gap-2">
-                              <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
+                            <div className="flex min-w-0 items-center gap-1.5">
+                              {handle}
                               <Input
                                 className="h-7 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
                                 value={subDraft?.label ?? sub.label}
@@ -594,22 +639,6 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
                               )}
                             </div>
                             <div className="flex shrink-0 items-center gap-0.5">
-                              <Button
-                                variant="ghost" size="icon" className="h-7 w-7"
-                                onClick={() => void handleMoveSubcategory(sub.id, 'up')}
-                                disabled={isSubBusy || subIdx === 0}
-                                aria-label="Move up"
-                              >
-                                <ArrowUp className="h-3 w-3" />
-                              </Button>
-                              <Button
-                                variant="ghost" size="icon" className="h-7 w-7"
-                                onClick={() => void handleMoveSubcategory(sub.id, 'down')}
-                                disabled={isSubBusy || subIdx === editCatSubcategories.length - 1}
-                                aria-label="Move down"
-                              >
-                                <ArrowDown className="h-3 w-3" />
-                              </Button>
                               {isSubDirty && (
                                 <Button
                                   variant="ghost" size="icon" className="h-7 w-7"
@@ -626,11 +655,29 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
                                 onCheckedChange={(checked) => updateSubcategoryDraft(sub, { is_active: checked })}
                                 disabled={isSubBusy}
                               />
-                              {isSubBusy && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+                              <Button
+                                variant="ghost" size="icon"
+                                className="h-7 w-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                                onClick={() => setDeletingSubcategory(sub)}
+                                disabled={isSubBusy}
+                                aria-label={`Delete ${sub.label}`}
+                              >
+                                {isSubBusy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+                              </Button>
                             </div>
                           </div>
-                          <div className="flex items-center gap-2 pl-3.5">
-                            <span className="shrink-0 text-[11px] text-muted-foreground">Approval flow</span>
+                          <div className="pl-8">
+                            <Textarea
+                              placeholder="Description shown to requesters (optional)"
+                              value={subDraft?.description ?? sub.description}
+                              onChange={(event) => updateSubcategoryDraft(sub, { description: event.target.value })}
+                              rows={2}
+                              className="min-h-[40px] resize-y text-sm"
+                              disabled={isSubBusy}
+                            />
+                          </div>
+                          <div className="flex items-center gap-2 pl-8">
+                            <span className="shrink-0 text-xs text-muted-foreground">Approval flow</span>
                             <Select
                               value={subFlowValue}
                               onValueChange={(value) =>
@@ -658,13 +705,13 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
                           </div>
                         </div>
                       );
-                    })}
-                  </div>
+                    }}
+                  </SortableList>
                 )}
               </div>
             </div>
           )}
-          <DialogFooter>
+          <SheetFooter className="mt-4 gap-2">
             <Button
               variant="outline"
               onClick={() => setEditCategoryId(null)}
@@ -680,9 +727,9 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
               {busyCategoryId ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
               Save changes
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
 
       {setupLoading ? (
         <div className="flex items-center justify-center gap-3 rounded-lg border border-border py-12 text-muted-foreground">
@@ -690,24 +737,19 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
           <span>Loading request setup...</span>
         </div>
       ) : setupError ? (
-        <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-border py-12 text-center">
-          <AlertCircle className="h-8 w-8 text-destructive" />
-          <div className="space-y-1">
-            <p className="font-medium text-foreground">Unable to load request setup</p>
-            <p className="text-sm text-muted-foreground">{setupError}</p>
-          </div>
-          <Button variant="outline" onClick={() => void handleRetry()}>
-            Retry
-          </Button>
-        </div>
+        <HrmsEmptyState
+          icon={AlertCircle}
+          title="Unable to load request setup"
+          description={setupError}
+          action={{ label: 'Retry', onClick: () => void handleRetry() }}
+        />
       ) : categories.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
-          <p className="text-sm text-muted-foreground">No categories yet. Add one to get started.</p>
-          <Button type="button" onClick={() => setIsAdding(true)} className="gap-2">
-            <Plus className="h-4 w-4" />
-            Add Category
-          </Button>
-        </div>
+        <HrmsEmptyState
+          icon={Plus}
+          title="No categories yet"
+          description="Add a request category to get started."
+          action={{ label: 'Add category', onClick: () => setIsAdding(true) }}
+        />
       ) : (
         <div className="space-y-3">
           <div className="flex items-center justify-between gap-3">
@@ -725,72 +767,64 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
               Add Category
             </Button>
           </div>
-          <div className="divide-y divide-border rounded-lg border">
-            {categories.map((category, index) => {
-              const catSubcategories = subcategoriesByCategory[category.key] ?? [];
-              const isBusy = busyCategoryId === category.id;
-              return (
-                <div key={category.id} className="flex items-center gap-3 px-4 py-3">
-                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="text-sm font-medium text-foreground">{category.label}</span>
-                      {!category.is_active && (
-                        <Badge variant="outline" className="px-1.5 py-0 text-[10px]">Archived</Badge>
-                      )}
-                      {catSubcategories.length > 0 && (
-                        <span className="text-xs text-muted-foreground">
-                          {catSubcategories.length} {catSubcategories.length === 1 ? 'subcategory' : 'subcategories'}
-                        </span>
+          <div className="overflow-hidden rounded-lg border">
+            <SortableList
+              items={orderedCategories}
+              getId={(category) => category.id}
+              onReorder={(ids) => void handleReorderCategories(ids)}
+              disabled={reordering}
+              className="divide-y divide-border"
+            >
+              {(category, { handle }) => {
+                const catSubcategories = subcategoriesByCategory[category.key] ?? [];
+                const isBusy = busyCategoryId === category.id;
+                return (
+                  <div className="flex items-center gap-2 px-3 py-3">
+                    {handle}
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-sm font-medium text-foreground">{category.label}</span>
+                        {!category.is_active && (
+                          <Badge variant="outline" className="px-1.5 py-0 text-xs">Archived</Badge>
+                        )}
+                        {catSubcategories.length > 0 && (
+                          <span className="text-xs text-muted-foreground">
+                            {catSubcategories.length} {catSubcategories.length === 1 ? 'subcategory' : 'subcategories'}
+                          </span>
+                        )}
+                      </div>
+                      {category.description && (
+                        <p className="truncate text-xs text-muted-foreground">{category.description}</p>
                       )}
                     </div>
-                    {category.description && (
-                      <p className="truncate text-xs text-muted-foreground">{category.description}</p>
-                    )}
+                    <div className="flex shrink-0 items-center gap-0.5">
+                      {isBusy ? (
+                        <Loader2 className="ml-1 h-4 w-4 animate-spin text-muted-foreground" />
+                      ) : (
+                        <>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setEditCategoryId(category.id)}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                            onClick={() => setDeleteCategoryId(category.id)}
+                            aria-label={`Delete ${category.label}`}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </>
+                      )}
+                    </div>
                   </div>
-                  <div className="flex shrink-0 items-center gap-0.5">
-                    <Button
-                      variant="ghost" size="icon" className="h-7 w-7"
-                      onClick={() => void handleMove(category.id, 'up')}
-                      disabled={isBusy || index === 0}
-                      aria-label={`Move ${category.label} up`}
-                    >
-                      <ArrowUp className="h-3 w-3" />
-                    </Button>
-                    <Button
-                      variant="ghost" size="icon" className="h-7 w-7"
-                      onClick={() => void handleMove(category.id, 'down')}
-                      disabled={isBusy || index === categories.length - 1}
-                      aria-label={`Move ${category.label} down`}
-                    >
-                      <ArrowDown className="h-3 w-3" />
-                    </Button>
-                    {isBusy ? (
-                      <Loader2 className="ml-1 h-4 w-4 animate-spin text-muted-foreground" />
-                    ) : (
-                      <>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => setEditCategoryId(category.id)}
-                          className="ml-1"
-                        >
-                          Edit
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                          onClick={() => setDeleteCategoryId(category.id)}
-                          aria-label={`Delete ${category.label}`}
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </Button>
-                      </>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
+                );
+              }}
+            </SortableList>
           </div>
         </div>
       )}
@@ -823,6 +857,33 @@ export function CategoryEditor({ companyId, actorId, onActiveCountChange }: Prop
           </AlertDialog>
         );
       })()}
+
+      {/* Subcategory delete confirmation */}
+      <AlertDialog
+        open={deletingSubcategory !== null}
+        onOpenChange={(open) => { if (!open) setDeletingSubcategory(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete subcategory</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deletingSubcategory
+                ? <>Permanently delete <strong>{deletingSubcategory.label}</strong>? This cannot be undone. If it is already used by requests or templates, you will be asked to deactivate it instead.</>
+                : 'Permanently delete this subcategory? This cannot be undone.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busySubcategoryId !== null}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => { if (deletingSubcategory) void handleDeleteSubcategory(deletingSubcategory); }}
+              disabled={busySubcategoryId !== null}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {busySubcategoryId ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/pages/tickets/request-setup/FormFieldEditor.tsx
+++ b/src/pages/tickets/request-setup/FormFieldEditor.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useMemo, useState } from 'react';
-import { AlertCircle, Loader2, Plus, Save, Trash2, X } from 'lucide-react';
+import { AlertCircle, ListPlus, Loader2, Plus, Save, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -22,6 +23,7 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+import { HrmsEmptyState } from '@/components/shared/HrmsEmptyState';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
 import { useRequestCategories } from '@/hooks/useRequestCategories';
@@ -259,28 +261,16 @@ export function FormFieldEditor({ companyId, actorId, onActiveCountChange }: Pro
         )}
       </div>
 
-      <Dialog open={isAdding} onOpenChange={(open) => {
+      <Sheet open={isAdding} onOpenChange={(open) => {
         setIsAdding(open);
         if (!open) resetCreateForm();
       }}>
-        <DialogContent className="max-w-3xl">
-          <DialogHeader>
-            <DialogTitle>New custom field</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-          <div className="flex items-center justify-between gap-3">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={() => { setIsAdding(false); resetCreateForm(); }}
-              disabled={creating}
-              aria-label="Cancel"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
-
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
+          <SheetHeader>
+            <SheetTitle>New custom field</SheetTitle>
+            <SheetDescription>Add a per-category field requesters complete before submitting.</SheetDescription>
+          </SheetHeader>
+          <div className="mt-4 space-y-4">
           <div className="grid gap-4 md:grid-cols-3">
             <div className="space-y-2">
               <Label htmlFor="field-create-category">Category <span className="text-destructive">*</span></Label>
@@ -386,18 +376,28 @@ export function FormFieldEditor({ companyId, actorId, onActiveCountChange }: Pro
             <Switch checked={createRequired} onCheckedChange={setCreateRequired} disabled={creating} />
           </div>
 
-          <Button
-            type="button"
-            onClick={() => void handleCreate()}
-            disabled={creating || !createCategoryKey || !createLabel.trim()}
-            className="gap-2"
-          >
-            {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-            Add field
-          </Button>
+          <SheetFooter className="gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => { setIsAdding(false); resetCreateForm(); }}
+              disabled={creating}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void handleCreate()}
+              disabled={creating || !createCategoryKey || !createLabel.trim()}
+              className="gap-2"
+            >
+              {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+              Add field
+            </Button>
+          </SheetFooter>
           </div>
-        </DialogContent>
-      </Dialog>
+        </SheetContent>
+      </Sheet>
 
       {loading ? (
         <div className="flex items-center justify-center gap-3 rounded-xl border border-border py-12 text-muted-foreground">
@@ -405,23 +405,19 @@ export function FormFieldEditor({ companyId, actorId, onActiveCountChange }: Pro
           <span>Loading form fields...</span>
         </div>
       ) : error ? (
-        <div className="flex flex-col items-center justify-center gap-4 rounded-xl border border-border py-12 text-center">
-          <AlertCircle className="h-8 w-8 text-destructive" />
-          <div className="space-y-1">
-            <p className="font-medium text-foreground">Unable to load form fields</p>
-            <p className="text-sm text-muted-foreground">{error}</p>
-          </div>
-          <Button variant="outline" onClick={() => void reload()}>Retry</Button>
-        </div>
+        <HrmsEmptyState
+          icon={AlertCircle}
+          title="Unable to load form fields"
+          description={error}
+          action={{ label: 'Retry', onClick: () => void reload() }}
+        />
       ) : fields.length === 0 ? (
-        !isAdding ? (
-          <div className="flex items-center justify-center py-16">
-            <Button type="button" onClick={() => setIsAdding(true)} className="gap-2">
-              <Plus className="h-4 w-4" />
-              Add Field
-            </Button>
-          </div>
-        ) : null
+        <HrmsEmptyState
+          icon={ListPlus}
+          title="No custom fields yet"
+          description="Add per-category fields requesters must complete before submitting a request."
+          action={{ label: 'Add field', onClick: () => setIsAdding(true) }}
+        />
       ) : (
         <div className="space-y-5">
           {categories.map((category) => {
@@ -468,12 +464,12 @@ export function FormFieldEditor({ companyId, actorId, onActiveCountChange }: Pro
                           </Button>
                           <Button
                             type="button"
-                            variant="outline"
+                            variant="ghost"
                             size="icon"
                             aria-label={`Delete ${field.label}`}
                             onClick={() => setDeletingField(field)}
                             disabled={isBusy}
-                            className="text-destructive hover:text-destructive"
+                            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                           >
                             {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
                           </Button>
@@ -488,13 +484,14 @@ export function FormFieldEditor({ companyId, actorId, onActiveCountChange }: Pro
         </div>
       )}
 
-      <Dialog open={!!editingField} onOpenChange={(open) => { if (!open) { setEditingFieldId(null); setConflictFieldId(null); } }}>
-        <DialogContent className="max-w-3xl">
-          <DialogHeader>
-            <DialogTitle>Edit custom field</DialogTitle>
-          </DialogHeader>
+      <Sheet open={!!editingField} onOpenChange={(open) => { if (!open) { setEditingFieldId(null); setConflictFieldId(null); } }}>
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
+          <SheetHeader>
+            <SheetTitle>Edit custom field</SheetTitle>
+            <SheetDescription>{editingField ? editingField.label : ''}</SheetDescription>
+          </SheetHeader>
           {editingField && editingDraft && (
-            <div className="space-y-4">
+            <div className="mt-4 space-y-4">
               {conflictFieldId === editingField.id && (
                 <Alert variant="destructive">
                   <AlertCircle className="h-4 w-4" />
@@ -594,7 +591,7 @@ export function FormFieldEditor({ companyId, actorId, onActiveCountChange }: Pro
               </div>
             </div>
           )}
-          <DialogFooter>
+          <SheetFooter className="mt-4 gap-2">
             <Button type="button" variant="outline" onClick={() => setEditingFieldId(null)} disabled={editingBusy}>Cancel</Button>
             <Button
               type="button"
@@ -605,9 +602,9 @@ export function FormFieldEditor({ companyId, actorId, onActiveCountChange }: Pro
               {editingBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
               Save changes
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
 
       <ConfirmDialog
         open={deletingField !== null}

--- a/src/pages/tickets/request-setup/RoutingEditor.tsx
+++ b/src/pages/tickets/request-setup/RoutingEditor.tsx
@@ -3,13 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import { STALE } from '@/lib/queryClient';
 import {
   AlertCircle,
-  ArrowDown,
-  ArrowUp,
   Loader2,
   Plus,
+  Route,
   Save,
   Trash2,
-  X,
 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -24,9 +22,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 import { Switch } from '@/components/ui/switch';
 import { ROLE_LABELS } from '@/config/rolePermissions';
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+import { HrmsEmptyState } from '@/components/shared/HrmsEmptyState';
+import { SortableList } from '@/components/ui/SortableList';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
 import { useRoutingRules } from '@/hooks/useRoutingRules';
@@ -36,7 +44,7 @@ import { listProfiles } from '@flc/auth';
 import {
   createRoutingRule,
   deleteRoutingRule,
-  moveRoutingRule,
+  reorderRoutingRules,
   updateRoutingRule,
   type RequestRoutingRule,
 } from '@flc/internal-requests';
@@ -98,6 +106,12 @@ export function RoutingEditor({ companyId, actorId, onActiveCountChange }: Props
   // optimistic-lock conflict (drives the inline "reload" banner).
   const [deletingRule, setDeletingRule] = useState<RequestRoutingRule | null>(null);
   const [conflictRuleId, setConflictRuleId] = useState<string | null>(null);
+
+  // Local mirror so drag-and-drop can reorder optimistically; re-synced from
+  // the hook's server state on every load/reload.
+  const [orderedRules, setOrderedRules] = useState<RequestRoutingRule[]>(rules);
+  const [reordering, setReordering] = useState(false);
+  useEffect(() => { setOrderedRules(rules); }, [rules]);
 
   const activeProfiles = useMemo(
     () => profiles.filter((p) => p.status === 'active' && !p.portal_access_only),
@@ -217,12 +231,15 @@ export function RoutingEditor({ companyId, actorId, onActiveCountChange }: Props
     setBusyRuleId(null);
   };
 
-  const handleMove = async (ruleId: string, direction: 'up' | 'down') => {
-    setBusyRuleId(ruleId);
-    const result = await moveRoutingRule(ruleId, direction, { actorId, companyId });
-    if (result.error) toast.error('Unable to reorder rule', { description: result.error });
-    else await reload();
-    setBusyRuleId(null);
+  const handleReorder = async (orderedIds: string[]) => {
+    const byId = new Map(orderedRules.map((rule) => [rule.id, rule]));
+    const next = orderedIds.map((id) => byId.get(id)).filter((rule): rule is RequestRoutingRule => Boolean(rule));
+    setOrderedRules(next);
+    setReordering(true);
+    const result = await reorderRoutingRules(orderedIds, { actorId, companyId });
+    if (result.error) toast.error('Unable to reorder rules', { description: result.error });
+    await reload();
+    setReordering(false);
   };
 
   const handleToggle = async (rule: RequestRoutingRule) => {
@@ -243,24 +260,37 @@ export function RoutingEditor({ companyId, actorId, onActiveCountChange }: Props
     setBusyRuleId(null);
   };
 
+  const editingRule = rules.find((rule) => rule.id === expandedRuleId) ?? null;
+  const editingDraft = editingRule ? ruleDrafts[editingRule.id] : undefined;
+  const editingDirty = editingRule ? hasRuleChanges(editingRule, editingDraft) : false;
+
+  const openEdit = (rule: RequestRoutingRule) => {
+    setRuleDrafts((prev) => ({
+      ...prev,
+      [rule.id]: {
+        name: rule.name,
+        match_category: rule.match_category ?? '',
+        match_subcategory: rule.match_subcategory ?? '',
+        match_submitter_role: rule.match_submitter_role ?? '',
+        match_priority: rule.match_priority ?? '',
+        assign_to_user_id: rule.assign_to_user_id,
+      },
+    }));
+    setExpandedRuleId(rule.id);
+  };
+
   return (
     <div className="space-y-4">
-      {isAdding && (
-        <div className="space-y-4 rounded-lg border border-dashed border-border/70 bg-secondary/20 p-4">
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-sm font-semibold text-foreground">New routing rule</p>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={() => { setIsAdding(false); resetCreateForm(); }}
-              disabled={creating}
-              aria-label="Cancel"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
-
+      <Sheet
+        open={isAdding}
+        onOpenChange={(open) => { setIsAdding(open); if (!open) resetCreateForm(); }}
+      >
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
+          <SheetHeader>
+            <SheetTitle>New routing rule</SheetTitle>
+            <SheetDescription>Route matching requests to a specific assignee.</SheetDescription>
+          </SheetHeader>
+          <div className="mt-4 space-y-4">
           <div className="space-y-2">
             <Label htmlFor="rule-create-name">Rule name <span className="text-destructive">*</span></Label>
             <Input
@@ -384,17 +414,28 @@ export function RoutingEditor({ companyId, actorId, onActiveCountChange }: Props
             </Select>
           </div>
 
-          <Button
-            type="button"
-            onClick={() => void handleCreate()}
-            disabled={creating || !createName.trim() || !createAssignTo}
-            className="gap-2"
-          >
-            {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-            Add rule
-          </Button>
-        </div>
-      )}
+          <SheetFooter className="mt-4 gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => { setIsAdding(false); resetCreateForm(); }}
+              disabled={creating}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void handleCreate()}
+              disabled={creating || !createName.trim() || !createAssignTo}
+              className="gap-2"
+            >
+              {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+              Add rule
+            </Button>
+          </SheetFooter>
+          </div>
+        </SheetContent>
+      </Sheet>
 
       {loading ? (
         <div className="flex items-center justify-center gap-3 rounded-xl border border-border py-12 text-muted-foreground">
@@ -402,23 +443,19 @@ export function RoutingEditor({ companyId, actorId, onActiveCountChange }: Props
           <span>Loading routing rules…</span>
         </div>
       ) : error ? (
-        <div className="flex flex-col items-center justify-center gap-4 rounded-xl border border-border py-12 text-center">
-          <AlertCircle className="h-8 w-8 text-destructive" />
-          <div className="space-y-1">
-            <p className="font-medium text-foreground">Unable to load routing rules</p>
-            <p className="text-sm text-muted-foreground">{error}</p>
-          </div>
-          <Button variant="outline" onClick={() => void reload()}>Retry</Button>
-        </div>
+        <HrmsEmptyState
+          icon={AlertCircle}
+          title="Unable to load routing rules"
+          description={error}
+          action={{ label: 'Retry', onClick: () => void reload() }}
+        />
       ) : rules.length === 0 ? (
-        !isAdding ? (
-          <div className="flex items-center justify-center py-16">
-            <Button type="button" onClick={() => setIsAdding(true)} className="gap-2">
-              <Plus className="h-4 w-4" />
-              Add Rule
-            </Button>
-          </div>
-        ) : null
+        <HrmsEmptyState
+          icon={Route}
+          title="No routing rules yet"
+          description="Add a rule to auto-assign matching requests to the right person."
+          action={{ label: 'Add rule', onClick: () => setIsAdding(true) }}
+        />
       ) : (
         <div className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
@@ -440,272 +477,254 @@ export function RoutingEditor({ companyId, actorId, onActiveCountChange }: Props
             )}
           </div>
 
-          {rules.map((rule, rIdx) => {
-            const isRuleBusy = busyRuleId === rule.id;
-            const isExpanded = expandedRuleId === rule.id;
-            const draft = ruleDrafts[rule.id];
-            const isDirty = hasRuleChanges(rule, draft);
-            const assignee = profiles.find((p) => p.id === rule.assign_to_user_id);
+          <SortableList
+            items={orderedRules}
+            getId={(rule) => rule.id}
+            onReorder={(ids) => void handleReorder(ids)}
+            disabled={reordering}
+            className="space-y-4"
+          >
+            {(rule, { handle }) => {
+              const isRuleBusy = busyRuleId === rule.id;
+              const assignee = profiles.find((p) => p.id === rule.assign_to_user_id);
 
-            return (
-              <div key={rule.id} className="space-y-4 rounded-xl border border-border bg-background p-4">
-                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                  <div className="space-y-2">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <p className="text-base font-semibold text-foreground">{rule.name}</p>
-                      <Badge variant={rule.is_active ? 'secondary' : 'outline'}>
-                        {rule.is_active ? 'Active' : 'Inactive'}
-                      </Badge>
+              return (
+                <div className="space-y-4 rounded-xl border border-border bg-background p-4">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="flex min-w-0 items-start gap-2">
+                      <div className="pt-0.5">{handle}</div>
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="text-base font-semibold text-foreground">{rule.name}</p>
+                          <Badge variant={rule.is_active ? 'secondary' : 'outline'}>
+                            {rule.is_active ? 'Active' : 'Inactive'}
+                          </Badge>
+                        </div>
+                        <div className="flex flex-wrap gap-1.5 text-xs">
+                          {rule.match_category ? (
+                            <Badge variant="outline">Category: {categories.find((c) => c.key === rule.match_category)?.label ?? rule.match_category}</Badge>
+                          ) : (
+                            <Badge variant="outline" className="text-muted-foreground">Any category</Badge>
+                          )}
+                          {rule.match_subcategory && (
+                            <Badge variant="outline">Subcategory: {subcategories.find((s) => s.key === rule.match_subcategory)?.label ?? rule.match_subcategory}</Badge>
+                          )}
+                          {rule.match_submitter_role && (
+                            <Badge variant="outline">Role: {ROLE_LABELS[rule.match_submitter_role as keyof typeof ROLE_LABELS] ?? rule.match_submitter_role}</Badge>
+                          )}
+                          {rule.match_priority && (
+                            <Badge variant="outline" className="capitalize">Priority: {rule.match_priority}</Badge>
+                          )}
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          Assign to: <span className="font-medium text-foreground">{assignee ? (assignee.name || assignee.email) : rule.assign_to_user_id}</span>
+                        </p>
+                      </div>
                     </div>
-                    <div className="flex flex-wrap gap-1.5 text-xs">
-                      {rule.match_category ? (
-                        <Badge variant="outline">Category: {categories.find((c) => c.key === rule.match_category)?.label ?? rule.match_category}</Badge>
-                      ) : (
-                        <Badge variant="outline" className="text-muted-foreground">Any category</Badge>
-                      )}
-                      {rule.match_subcategory && (
-                        <Badge variant="outline">Subcategory: {subcategories.find((s) => s.key === rule.match_subcategory)?.label ?? rule.match_subcategory}</Badge>
-                      )}
-                      {rule.match_submitter_role && (
-                        <Badge variant="outline">Role: {ROLE_LABELS[rule.match_submitter_role as keyof typeof ROLE_LABELS] ?? rule.match_submitter_role}</Badge>
-                      )}
-                      {rule.match_priority && (
-                        <Badge variant="outline" className="capitalize">Priority: {rule.match_priority}</Badge>
-                      )}
-                    </div>
-                    <p className="text-sm text-muted-foreground">
-                      Assign to: <span className="font-medium text-foreground">{assignee ? (assignee.name || assignee.email) : rule.assign_to_user_id}</span>
-                    </p>
-                  </div>
 
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      aria-label={`Move ${rule.name} up`}
-                      onClick={() => void handleMove(rule.id, 'up')}
-                      disabled={isRuleBusy || rIdx === 0}
-                    >
-                      <ArrowUp className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      aria-label={`Move ${rule.name} down`}
-                      onClick={() => void handleMove(rule.id, 'down')}
-                      disabled={isRuleBusy || rIdx === rules.length - 1}
-                    >
-                      <ArrowDown className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => {
-                        if (isExpanded) {
-                          setExpandedRuleId(null);
-                        } else {
-                          setRuleDrafts((prev) => ({
-                            ...prev,
-                            [rule.id]: {
-                              name: rule.name,
-                              match_category: rule.match_category ?? '',
-                              match_subcategory: rule.match_subcategory ?? '',
-                              match_submitter_role: rule.match_submitter_role ?? '',
-                              match_priority: rule.match_priority ?? '',
-                              assign_to_user_id: rule.assign_to_user_id,
-                            },
-                          }));
-                          setExpandedRuleId(rule.id);
-                        }
-                      }}
-                      disabled={isRuleBusy}
-                    >
-                      {isExpanded ? 'Collapse' : 'Edit'}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      aria-label={`Delete ${rule.name}`}
-                      onClick={() => setDeletingRule(rule)}
-                      disabled={isRuleBusy}
-                      className="text-destructive hover:text-destructive"
-                    >
-                      {isRuleBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-                    </Button>
-                  </div>
-                </div>
-
-                <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border px-4 py-3">
-                  <div>
-                    <p className="text-sm font-medium text-foreground">Rule active</p>
-                    <p className="text-xs text-muted-foreground">
-                      Inactive rules are skipped during evaluation.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={rule.is_active}
-                    onCheckedChange={() => void handleToggle(rule)}
-                    disabled={isRuleBusy}
-                  />
-                </div>
-
-                {isExpanded && draft && (
-                  <div className="space-y-4 rounded-xl border border-dashed border-border/70 bg-secondary/10 p-4">
-                    {conflictRuleId === rule.id && (
-                      <Alert variant="destructive">
-                        <AlertCircle className="h-4 w-4" />
-                        <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
-                          <span>{CONFLICT_RELOAD_MESSAGE}</span>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => {
-                              setConflictRuleId(null);
-                              setExpandedRuleId(null);
-                              void reload();
-                            }}
-                          >
-                            Reload
-                          </Button>
-                        </AlertDescription>
-                      </Alert>
-                    )}
-                    <div className="space-y-2">
-                      <Label htmlFor={`rule-name-${rule.id}`}>Rule name</Label>
-                      <Input
-                        id={`rule-name-${rule.id}`}
-                        value={draft.name}
-                        onChange={(event) => updateDraft(rule, { name: event.target.value })}
+                    <div className="flex flex-wrap items-center gap-1">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => openEdit(rule)}
                         disabled={isRuleBusy}
-                      />
-                    </div>
-
-                    <div className="grid gap-4 md:grid-cols-2">
-                      <div className="space-y-2">
-                        <Label htmlFor={`rule-cat-${rule.id}`}>Category condition</Label>
-                        <Select
-                          value={selectValue(draft.match_category)}
-                          onValueChange={(value) => updateDraft(rule, {
-                            match_category: optionalSelectValue(value),
-                            match_subcategory: '',
-                          })}
-                          disabled={isRuleBusy}
-                        >
-                          <SelectTrigger id={`rule-cat-${rule.id}`}>
-                            <SelectValue placeholder="Any category" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value={ANY_SELECT_VALUE}>Any category</SelectItem>
-                            {categories.filter((c) => c.is_active).map((c) => (
-                              <SelectItem key={c.key} value={c.key}>{c.label}</SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor={`rule-subcat-${rule.id}`}>Subcategory condition</Label>
-                        <Select
-                          value={selectValue(draft.match_subcategory)}
-                          onValueChange={(value) => updateDraft(rule, { match_subcategory: optionalSelectValue(value) })}
-                          disabled={isRuleBusy || !draft.match_category}
-                        >
-                          <SelectTrigger id={`rule-subcat-${rule.id}`}>
-                            <SelectValue placeholder="Any subcategory" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value={ANY_SELECT_VALUE}>Any subcategory</SelectItem>
-                            {activeSubcategoriesForKey(draft.match_category).map((s) => (
-                              <SelectItem key={s.key} value={s.key}>{s.label}</SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </div>
-
-                    <div className="grid gap-4 md:grid-cols-2">
-                      <div className="space-y-2">
-                        <Label htmlFor={`rule-role-${rule.id}`}>Submitter role condition</Label>
-                        <Select
-                          value={selectValue(draft.match_submitter_role)}
-                          onValueChange={(value) => updateDraft(rule, { match_submitter_role: optionalSelectValue(value) })}
-                          disabled={isRuleBusy}
-                        >
-                          <SelectTrigger id={`rule-role-${rule.id}`}>
-                            <SelectValue placeholder="Any role" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value={ANY_SELECT_VALUE}>Any role</SelectItem>
-                            {(Object.entries(ROLE_LABELS) as [string, string][]).map(([key, label]) => (
-                              <SelectItem key={key} value={key}>{label}</SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor={`rule-priority-${rule.id}`}>Priority condition</Label>
-                        <Select
-                          value={selectValue(draft.match_priority)}
-                          onValueChange={(value) => updateDraft(rule, { match_priority: optionalSelectValue(value) })}
-                          disabled={isRuleBusy}
-                        >
-                          <SelectTrigger id={`rule-priority-${rule.id}`}>
-                            <SelectValue placeholder="Any priority" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value={ANY_SELECT_VALUE}>Any priority</SelectItem>
-                            {PRIORITY_OPTIONS.map((p) => (
-                              <SelectItem key={p.value} value={p.value}>{p.label}</SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor={`rule-assign-${rule.id}`}>Assign to</Label>
-                      <Select
-                        value={draft.assign_to_user_id}
-                        onValueChange={(v) => updateDraft(rule, { assign_to_user_id: v })}
-                        disabled={isRuleBusy || profilesLoading}
                       >
-                        <SelectTrigger id={`rule-assign-${rule.id}`}>
-                          <SelectValue placeholder={profilesLoading ? 'Loading…' : 'Select assignee'} />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {activeProfiles.map((p) => (
-                            <SelectItem key={p.id} value={p.id}>
-                              {p.name || p.email}
-                              {p.role && (
-                                <span className="ml-1.5 text-xs text-muted-foreground">
-                                  ({ROLE_LABELS[p.role] ?? p.role})
-                                </span>
-                              )}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                        Edit
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Delete ${rule.name}`}
+                        onClick={() => setDeletingRule(rule)}
+                        disabled={isRuleBusy}
+                        className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                      >
+                        {isRuleBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                      </Button>
                     </div>
-
-                    <Button
-                      type="button"
-                      onClick={() => void handleSave(rule)}
-                      disabled={isRuleBusy || !isDirty}
-                      className="gap-2"
-                    >
-                      {isRuleBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-                      Save changes
-                    </Button>
                   </div>
-                )}
-              </div>
-            );
-          })}
+
+                  <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border px-4 py-3">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">Rule active</p>
+                      <p className="text-xs text-muted-foreground">
+                        Inactive rules are skipped during evaluation.
+                      </p>
+                    </div>
+                    <Switch
+                      checked={rule.is_active}
+                      onCheckedChange={() => void handleToggle(rule)}
+                      disabled={isRuleBusy}
+                    />
+                  </div>
+                </div>
+              );
+            }}
+          </SortableList>
         </div>
       )}
+
+      {/* Edit routing rule drawer */}
+      <Sheet
+        open={!!editingRule}
+        onOpenChange={(open) => { if (!open) { setExpandedRuleId(null); setConflictRuleId(null); } }}
+      >
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
+          <SheetHeader>
+            <SheetTitle>Edit routing rule</SheetTitle>
+            <SheetDescription>{editingRule?.name ?? ''}</SheetDescription>
+          </SheetHeader>
+          {editingRule && editingDraft && (
+            <div className="mt-4 space-y-4">
+              {conflictRuleId === editingRule.id && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+                    <span>{CONFLICT_RELOAD_MESSAGE}</span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => { setConflictRuleId(null); setExpandedRuleId(null); void reload(); }}
+                    >
+                      Reload
+                    </Button>
+                  </AlertDescription>
+                </Alert>
+              )}
+              <div className="space-y-2">
+                <Label htmlFor={`rule-name-${editingRule.id}`}>Rule name</Label>
+                <Input
+                  id={`rule-name-${editingRule.id}`}
+                  value={editingDraft.name}
+                  onChange={(event) => updateDraft(editingRule, { name: event.target.value })}
+                  disabled={busyRuleId === editingRule.id}
+                />
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor={`rule-cat-${editingRule.id}`}>Category condition</Label>
+                  <Select
+                    value={selectValue(editingDraft.match_category)}
+                    onValueChange={(value) => updateDraft(editingRule, {
+                      match_category: optionalSelectValue(value),
+                      match_subcategory: '',
+                    })}
+                    disabled={busyRuleId === editingRule.id}
+                  >
+                    <SelectTrigger id={`rule-cat-${editingRule.id}`}>
+                      <SelectValue placeholder="Any category" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ANY_SELECT_VALUE}>Any category</SelectItem>
+                      {categories.filter((c) => c.is_active).map((c) => (
+                        <SelectItem key={c.key} value={c.key}>{c.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`rule-subcat-${editingRule.id}`}>Subcategory condition</Label>
+                  <Select
+                    value={selectValue(editingDraft.match_subcategory)}
+                    onValueChange={(value) => updateDraft(editingRule, { match_subcategory: optionalSelectValue(value) })}
+                    disabled={busyRuleId === editingRule.id || !editingDraft.match_category}
+                  >
+                    <SelectTrigger id={`rule-subcat-${editingRule.id}`}>
+                      <SelectValue placeholder="Any subcategory" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ANY_SELECT_VALUE}>Any subcategory</SelectItem>
+                      {activeSubcategoriesForKey(editingDraft.match_category).map((s) => (
+                        <SelectItem key={s.key} value={s.key}>{s.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor={`rule-role-${editingRule.id}`}>Submitter role condition</Label>
+                  <Select
+                    value={selectValue(editingDraft.match_submitter_role)}
+                    onValueChange={(value) => updateDraft(editingRule, { match_submitter_role: optionalSelectValue(value) })}
+                    disabled={busyRuleId === editingRule.id}
+                  >
+                    <SelectTrigger id={`rule-role-${editingRule.id}`}>
+                      <SelectValue placeholder="Any role" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ANY_SELECT_VALUE}>Any role</SelectItem>
+                      {(Object.entries(ROLE_LABELS) as [string, string][]).map(([key, label]) => (
+                        <SelectItem key={key} value={key}>{label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`rule-priority-${editingRule.id}`}>Priority condition</Label>
+                  <Select
+                    value={selectValue(editingDraft.match_priority)}
+                    onValueChange={(value) => updateDraft(editingRule, { match_priority: optionalSelectValue(value) })}
+                    disabled={busyRuleId === editingRule.id}
+                  >
+                    <SelectTrigger id={`rule-priority-${editingRule.id}`}>
+                      <SelectValue placeholder="Any priority" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ANY_SELECT_VALUE}>Any priority</SelectItem>
+                      {PRIORITY_OPTIONS.map((p) => (
+                        <SelectItem key={p.value} value={p.value}>{p.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={`rule-assign-${editingRule.id}`}>Assign to</Label>
+                <Select
+                  value={editingDraft.assign_to_user_id}
+                  onValueChange={(v) => updateDraft(editingRule, { assign_to_user_id: v })}
+                  disabled={busyRuleId === editingRule.id || profilesLoading}
+                >
+                  <SelectTrigger id={`rule-assign-${editingRule.id}`}>
+                    <SelectValue placeholder={profilesLoading ? 'Loading…' : 'Select assignee'} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {activeProfiles.map((p) => (
+                      <SelectItem key={p.id} value={p.id}>
+                        {p.name || p.email}
+                        {p.role && (
+                          <span className="ml-1.5 text-xs text-muted-foreground">
+                            ({ROLE_LABELS[p.role] ?? p.role})
+                          </span>
+                        )}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          )}
+          <SheetFooter className="mt-4 gap-2">
+            <Button type="button" variant="outline" onClick={() => setExpandedRuleId(null)} disabled={!!busyRuleId}>Cancel</Button>
+            <Button
+              type="button"
+              onClick={() => { if (editingRule) void handleSave(editingRule); }}
+              disabled={!editingRule || busyRuleId === editingRule?.id || !editingDirty}
+              className="gap-2"
+            >
+              {editingRule && busyRuleId === editingRule.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+              Save changes
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
 
       <ConfirmDialog
         open={deletingRule !== null}

--- a/src/pages/tickets/request-setup/TemplateEditor.tsx
+++ b/src/pages/tickets/request-setup/TemplateEditor.tsx
@@ -1,13 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AlertCircle,
-  ArrowDown,
-  ArrowUp,
+  FileText,
   Loader2,
   Plus,
   Save,
   Trash2,
-  X,
 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -22,8 +20,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { HrmsEmptyState } from '@/components/shared/HrmsEmptyState';
+import { SortableList } from '@/components/ui/SortableList';
 
 import { useRequestCategories } from '@/hooks/useRequestCategories';
 import { useRequestSubcategories } from '@/hooks/useRequestSubcategories';
@@ -31,7 +39,7 @@ import { useRequestTemplates } from '@/hooks/useRequestTemplates';
 import {
   createRequestTemplate,
   deleteRequestTemplate,
-  moveRequestTemplate,
+  reorderRequestTemplates,
   updateRequestTemplate,
   type RequestTemplateRecord,
   type TemplatePriority,
@@ -74,6 +82,11 @@ export function TemplateEditor({ companyId, actorId, onActiveCountChange }: Prop
   const [templateDrafts, setTemplateDrafts] = useState<Record<string, TemplateDraft>>({});
   const [busyTemplateId, setBusyTemplateId] = useState<string | null>(null);
   const [expandedTemplateId, setExpandedTemplateId] = useState<string | null>(null);
+
+  // Local mirror for optimistic drag-and-drop reorder; re-synced from server.
+  const [orderedTemplates, setOrderedTemplates] = useState<RequestTemplateRecord[]>(templates);
+  const [reordering, setReordering] = useState(false);
+  useEffect(() => { setOrderedTemplates(templates); }, [templates]);
 
   useEffect(() => {
     setTemplateDrafts(
@@ -187,12 +200,15 @@ export function TemplateEditor({ companyId, actorId, onActiveCountChange }: Prop
     setBusyTemplateId(null);
   };
 
-  const handleMove = async (templateId: string, direction: 'up' | 'down') => {
-    setBusyTemplateId(templateId);
-    const result = await moveRequestTemplate(templateId, direction, { actorId, companyId });
+  const handleReorder = async (orderedIds: string[]) => {
+    const byId = new Map(orderedTemplates.map((t) => [t.id, t]));
+    const next = orderedIds.map((id) => byId.get(id)).filter((t): t is RequestTemplateRecord => Boolean(t));
+    setOrderedTemplates(next);
+    setReordering(true);
+    const result = await reorderRequestTemplates(orderedIds, { actorId, companyId });
     if (result.error) toast.error('Unable to reorder templates', { description: result.error });
-    else await reload();
-    setBusyTemplateId(null);
+    await reload();
+    setReordering(false);
   };
 
   const handleDelete = async (templateId: string, templateName: string) => {
@@ -208,24 +224,25 @@ export function TemplateEditor({ companyId, actorId, onActiveCountChange }: Prop
     setBusyTemplateId(null);
   };
 
+  const editingTemplate = templates.find((t) => t.id === expandedTemplateId) ?? null;
+  const editingDraft = editingTemplate ? templateDrafts[editingTemplate.id] : undefined;
+  const editingDirty = editingTemplate ? hasTemplateChanges(editingTemplate, editingDraft) : false;
+  const editingSubcategories = editingDraft
+    ? activeSubcategoriesForKey(editingDraft.category_key)
+    : [];
+
   return (
     <div className="space-y-4">
-      {isAdding && (
-        <div className="space-y-4 rounded-lg border border-dashed border-border/70 bg-secondary/20 p-4">
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-sm font-semibold text-foreground">New template</p>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={() => { setIsAdding(false); resetCreateForm(); }}
-              disabled={creating}
-              aria-label="Cancel"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
-
+      <Sheet
+        open={isAdding}
+        onOpenChange={(open) => { setIsAdding(open); if (!open) resetCreateForm(); }}
+      >
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
+          <SheetHeader>
+            <SheetTitle>New template</SheetTitle>
+            <SheetDescription>Pre-fill a request so employees start from a ready draft.</SheetDescription>
+          </SheetHeader>
+          <div className="mt-4 space-y-4">
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="template-create-name">Template name <span className="text-destructive">*</span></Label>
@@ -325,23 +342,34 @@ export function TemplateEditor({ companyId, actorId, onActiveCountChange }: Prop
             />
           </div>
 
-          <Button
-            type="button"
-            onClick={() => void handleCreate()}
-            disabled={
-              creating
-              || createName.trim().length === 0
-              || !createCategoryKey
-              || createSubject.trim().length === 0
-              || createBody.trim().length === 0
-            }
-            className="gap-2"
-          >
-            {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-            Add template
-          </Button>
-        </div>
-      )}
+          <SheetFooter className="mt-4 gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => { setIsAdding(false); resetCreateForm(); }}
+              disabled={creating}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void handleCreate()}
+              disabled={
+                creating
+                || createName.trim().length === 0
+                || !createCategoryKey
+                || createSubject.trim().length === 0
+                || createBody.trim().length === 0
+              }
+              className="gap-2"
+            >
+              {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+              Add template
+            </Button>
+          </SheetFooter>
+          </div>
+        </SheetContent>
+      </Sheet>
 
       {loading ? (
         <div className="flex items-center justify-center gap-3 rounded-xl border border-border py-12 text-muted-foreground">
@@ -349,23 +377,19 @@ export function TemplateEditor({ companyId, actorId, onActiveCountChange }: Prop
           <span>Loading templates...</span>
         </div>
       ) : error ? (
-        <div className="flex flex-col items-center justify-center gap-4 rounded-xl border border-border py-12 text-center">
-          <AlertCircle className="h-8 w-8 text-destructive" />
-          <div className="space-y-1">
-            <p className="font-medium text-foreground">Unable to load templates</p>
-            <p className="text-sm text-muted-foreground">{error}</p>
-          </div>
-          <Button variant="outline" onClick={() => void reload()}>Retry</Button>
-        </div>
+        <HrmsEmptyState
+          icon={AlertCircle}
+          title="Unable to load templates"
+          description={error}
+          action={{ label: 'Retry', onClick: () => void reload() }}
+        />
       ) : templates.length === 0 ? (
-        !isAdding ? (
-          <div className="flex items-center justify-center py-16">
-            <Button type="button" onClick={() => setIsAdding(true)} className="gap-2">
-              <Plus className="h-4 w-4" />
-              Add Template
-            </Button>
-          </div>
-        ) : null
+        <HrmsEmptyState
+          icon={FileText}
+          title="No templates yet"
+          description="Add a template so requesters can start from a ready-made draft."
+          action={{ label: 'Add template', onClick: () => setIsAdding(true) }}
+        />
       ) : (
         <div className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
@@ -380,203 +404,204 @@ export function TemplateEditor({ companyId, actorId, onActiveCountChange }: Prop
             )}
           </div>
 
-          {templates.map((template, tIdx) => {
-            const draft = templateDrafts[template.id];
-            const isBusy = busyTemplateId === template.id;
-            const isDirty = hasTemplateChanges(template, draft);
-            const isExpanded = expandedTemplateId === template.id;
-            const draftCategoryKey = draft?.category_key ?? template.category_key;
-            const draftSubcategories = activeSubcategoriesForKey(draftCategoryKey);
+          <SortableList
+            items={orderedTemplates}
+            getId={(template) => template.id}
+            onReorder={(ids) => void handleReorder(ids)}
+            disabled={reordering}
+            className="space-y-4"
+          >
+            {(template, { handle }) => {
+              const isBusy = busyTemplateId === template.id;
 
-            return (
-              <div key={template.id} className="space-y-4 rounded-xl border border-border bg-background p-4">
-                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                  <div className="space-y-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <p className="text-base font-semibold text-foreground">{template.name}</p>
-                      <Badge variant={template.is_active ? 'secondary' : 'outline'}>
-                        {template.is_active ? 'Active' : 'Archived'}
-                      </Badge>
-                      <Badge variant="outline" className="capitalize">{template.priority}</Badge>
-                    </div>
-                    {template.description && (
-                      <p className="text-sm text-muted-foreground">{template.description}</p>
-                    )}
-                    <p className="text-xs text-muted-foreground">
-                      Category: <span className="font-medium">{categories.find((c) => c.key === template.category_key)?.label ?? template.category_key}</span>
-                      {template.subcategory_key && (
-                        <> · Subcategory: <span className="font-medium">{subcategories.find((s) => s.key === template.subcategory_key)?.label ?? template.subcategory_key}</span></>
-                      )}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      aria-label={`Move ${template.name} up`}
-                      onClick={() => void handleMove(template.id, 'up')}
-                      disabled={isBusy || tIdx === 0}
-                    >
-                      <ArrowUp className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      aria-label={`Move ${template.name} down`}
-                      onClick={() => void handleMove(template.id, 'down')}
-                      disabled={isBusy || tIdx === templates.length - 1}
-                    >
-                      <ArrowDown className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => setExpandedTemplateId(isExpanded ? null : template.id)}
-                      disabled={isBusy}
-                    >
-                      {isExpanded ? 'Collapse' : 'Edit'}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      aria-label={`Delete ${template.name}`}
-                      onClick={() => void handleDelete(template.id, template.name)}
-                      disabled={isBusy}
-                      className="text-destructive hover:text-destructive"
-                    >
-                      {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-                    </Button>
-                  </div>
-                </div>
-
-                {isExpanded && draft && (
-                  <div className="space-y-4 rounded-xl border border-dashed border-border/70 bg-secondary/10 p-4">
-                    <div className="grid gap-4 md:grid-cols-2">
-                      <div className="space-y-2">
-                        <Label htmlFor={`template-name-${template.id}`}>Template name</Label>
-                        <Input
-                          id={`template-name-${template.id}`}
-                          value={draft.name}
-                          onChange={(event) => updateDraft(template, { name: event.target.value })}
-                          disabled={isBusy}
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor={`template-desc-${template.id}`}>Description</Label>
-                        <Input
-                          id={`template-desc-${template.id}`}
-                          value={draft.description}
-                          onChange={(event) => updateDraft(template, { description: event.target.value })}
-                          disabled={isBusy}
-                        />
-                      </div>
-                    </div>
-
-                    <div className="grid gap-4 md:grid-cols-3">
-                      <div className="space-y-2">
-                        <Label htmlFor={`template-cat-${template.id}`}>Category</Label>
-                        <Select
-                          value={draft.category_key}
-                          onValueChange={(v) => updateDraft(template, { category_key: v, subcategory_key: '' })}
-                          disabled={isBusy || categories.length === 0}
-                        >
-                          <SelectTrigger id={`template-cat-${template.id}`}><SelectValue /></SelectTrigger>
-                          <SelectContent>
-                            {categories.map((c) => (
-                              <SelectItem key={c.key} value={c.key}>{c.label}</SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor={`template-subcat-${template.id}`}>Subcategory</Label>
-                        <Select
-                          value={draft.subcategory_key || NONE_SELECT_VALUE}
-                          onValueChange={(value) => updateDraft(template, { subcategory_key: optionalSelectValue(value) })}
-                          disabled={isBusy || draftSubcategories.length === 0}
-                        >
-                          <SelectTrigger id={`template-subcat-${template.id}`}>
-                            <SelectValue placeholder="None" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value={NONE_SELECT_VALUE}>None</SelectItem>
-                            {draftSubcategories.map((s) => (
-                              <SelectItem key={s.key} value={s.key}>{s.label}</SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor={`template-priority-${template.id}`}>Priority</Label>
-                        <Select
-                          value={draft.priority}
-                          onValueChange={(v) => updateDraft(template, { priority: v as TemplatePriority })}
-                          disabled={isBusy}
-                        >
-                          <SelectTrigger id={`template-priority-${template.id}`}><SelectValue /></SelectTrigger>
-                          <SelectContent>
-                            {PRIORITY_OPTIONS.map((p) => (
-                              <SelectItem key={p.value} value={p.value}>{p.label}</SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor={`template-subject-${template.id}`}>Subject</Label>
-                      <Input
-                        id={`template-subject-${template.id}`}
-                        value={draft.subject}
-                        onChange={(event) => updateDraft(template, { subject: event.target.value })}
-                        disabled={isBusy}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor={`template-body-${template.id}`}>Body</Label>
-                      <Textarea
-                        id={`template-body-${template.id}`}
-                        value={draft.body}
-                        onChange={(event) => updateDraft(template, { body: event.target.value })}
-                        rows={5}
-                        disabled={isBusy}
-                      />
-                    </div>
-
-                    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border px-4 py-3">
-                      <div>
-                        <p className="text-sm font-medium text-foreground">Available to requesters</p>
+              return (
+                <div className="space-y-4 rounded-xl border border-border bg-background p-4">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="flex min-w-0 items-start gap-2">
+                      <div className="pt-0.5">{handle}</div>
+                      <div className="space-y-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="text-base font-semibold text-foreground">{template.name}</p>
+                          <Badge variant={template.is_active ? 'secondary' : 'outline'}>
+                            {template.is_active ? 'Active' : 'Archived'}
+                          </Badge>
+                          <Badge variant="outline" className="capitalize">{template.priority}</Badge>
+                        </div>
+                        {template.description && (
+                          <p className="text-sm text-muted-foreground">{template.description}</p>
+                        )}
                         <p className="text-xs text-muted-foreground">
-                          Archive to hide this template without deleting it.
+                          Category: <span className="font-medium">{categories.find((c) => c.key === template.category_key)?.label ?? template.category_key}</span>
+                          {template.subcategory_key && (
+                            <> · Subcategory: <span className="font-medium">{subcategories.find((s) => s.key === template.subcategory_key)?.label ?? template.subcategory_key}</span></>
+                          )}
                         </p>
                       </div>
-                      <Switch
-                        checked={draft.is_active}
-                        onCheckedChange={(checked) => updateDraft(template, { is_active: checked })}
-                        disabled={isBusy}
-                      />
                     </div>
-
-                    <Button
-                      type="button"
-                      onClick={() => void handleSave(template)}
-                      disabled={isBusy || !isDirty}
-                      className="gap-2"
-                    >
-                      {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-                      Save changes
-                    </Button>
+                    <div className="flex flex-wrap items-center gap-1">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setExpandedTemplateId(template.id)}
+                        disabled={isBusy}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Delete ${template.name}`}
+                        onClick={() => void handleDelete(template.id, template.name)}
+                        disabled={isBusy}
+                        className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                      >
+                        {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                      </Button>
+                    </div>
                   </div>
-                )}
-              </div>
-            );
-          })}
+                </div>
+              );
+            }}
+          </SortableList>
         </div>
       )}
+
+      {/* Edit template drawer */}
+      <Sheet
+        open={!!editingTemplate}
+        onOpenChange={(open) => { if (!open) setExpandedTemplateId(null); }}
+      >
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
+          <SheetHeader>
+            <SheetTitle>Edit template</SheetTitle>
+            <SheetDescription>{editingTemplate?.name ?? ''}</SheetDescription>
+          </SheetHeader>
+          {editingTemplate && editingDraft && (
+            <div className="mt-4 space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor={`template-name-${editingTemplate.id}`}>Template name</Label>
+                  <Input
+                    id={`template-name-${editingTemplate.id}`}
+                    value={editingDraft.name}
+                    onChange={(event) => updateDraft(editingTemplate, { name: event.target.value })}
+                    disabled={busyTemplateId === editingTemplate.id}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`template-desc-${editingTemplate.id}`}>Description</Label>
+                  <Input
+                    id={`template-desc-${editingTemplate.id}`}
+                    value={editingDraft.description}
+                    onChange={(event) => updateDraft(editingTemplate, { description: event.target.value })}
+                    disabled={busyTemplateId === editingTemplate.id}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="space-y-2">
+                  <Label htmlFor={`template-cat-${editingTemplate.id}`}>Category</Label>
+                  <Select
+                    value={editingDraft.category_key}
+                    onValueChange={(v) => updateDraft(editingTemplate, { category_key: v, subcategory_key: '' })}
+                    disabled={busyTemplateId === editingTemplate.id || categories.length === 0}
+                  >
+                    <SelectTrigger id={`template-cat-${editingTemplate.id}`}><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {categories.map((c) => (
+                        <SelectItem key={c.key} value={c.key}>{c.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`template-subcat-${editingTemplate.id}`}>Subcategory</Label>
+                  <Select
+                    value={editingDraft.subcategory_key || NONE_SELECT_VALUE}
+                    onValueChange={(value) => updateDraft(editingTemplate, { subcategory_key: optionalSelectValue(value) })}
+                    disabled={busyTemplateId === editingTemplate.id || editingSubcategories.length === 0}
+                  >
+                    <SelectTrigger id={`template-subcat-${editingTemplate.id}`}>
+                      <SelectValue placeholder="None" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={NONE_SELECT_VALUE}>None</SelectItem>
+                      {editingSubcategories.map((s) => (
+                        <SelectItem key={s.key} value={s.key}>{s.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`template-priority-${editingTemplate.id}`}>Priority</Label>
+                  <Select
+                    value={editingDraft.priority}
+                    onValueChange={(v) => updateDraft(editingTemplate, { priority: v as TemplatePriority })}
+                    disabled={busyTemplateId === editingTemplate.id}
+                  >
+                    <SelectTrigger id={`template-priority-${editingTemplate.id}`}><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {PRIORITY_OPTIONS.map((p) => (
+                        <SelectItem key={p.value} value={p.value}>{p.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={`template-subject-${editingTemplate.id}`}>Subject</Label>
+                <Input
+                  id={`template-subject-${editingTemplate.id}`}
+                  value={editingDraft.subject}
+                  onChange={(event) => updateDraft(editingTemplate, { subject: event.target.value })}
+                  disabled={busyTemplateId === editingTemplate.id}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={`template-body-${editingTemplate.id}`}>Body</Label>
+                <Textarea
+                  id={`template-body-${editingTemplate.id}`}
+                  value={editingDraft.body}
+                  onChange={(event) => updateDraft(editingTemplate, { body: event.target.value })}
+                  rows={5}
+                  disabled={busyTemplateId === editingTemplate.id}
+                />
+              </div>
+
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border px-4 py-3">
+                <div>
+                  <p className="text-sm font-medium text-foreground">Available to requesters</p>
+                  <p className="text-xs text-muted-foreground">
+                    Archive to hide this template without deleting it.
+                  </p>
+                </div>
+                <Switch
+                  checked={editingDraft.is_active}
+                  onCheckedChange={(checked) => updateDraft(editingTemplate, { is_active: checked })}
+                  disabled={busyTemplateId === editingTemplate.id}
+                />
+              </div>
+            </div>
+          )}
+          <SheetFooter className="mt-4 gap-2">
+            <Button type="button" variant="outline" onClick={() => setExpandedTemplateId(null)} disabled={!!busyTemplateId}>Cancel</Button>
+            <Button
+              type="button"
+              onClick={() => { if (editingTemplate) void handleSave(editingTemplate); }}
+              disabled={!editingTemplate || busyTemplateId === editingTemplate?.id || !editingDirty}
+              className="gap-2"
+            >
+              {editingTemplate && busyTemplateId === editingTemplate.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+              Save changes
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/src/services/requestCategoryService.ts
+++ b/src/services/requestCategoryService.ts
@@ -4,6 +4,7 @@ export {
   deleteRequestCategory,
   listRequestCategories,
   moveRequestCategory,
+  reorderRequestCategories,
   updateRequestCategory,
 } from '@flc/internal-requests';
 export type {

--- a/src/services/requestSubcategoryService.ts
+++ b/src/services/requestSubcategoryService.ts
@@ -1,12 +1,15 @@
 // Compatibility re-export: internal request subcategory behavior is owned by @flc/internal-requests.
 export {
   createRequestSubcategory,
+  deleteRequestSubcategory,
   listRequestSubcategories,
   moveRequestSubcategory,
+  reorderRequestSubcategories,
   updateRequestSubcategory,
 } from '@flc/internal-requests';
 export type {
   CreateRequestSubcategoryInput,
+  DeleteRequestSubcategoryResult,
   ListRequestSubcategoriesOptions,
   RequestSubcategoryContext,
   RequestSubcategoryRecord,


### PR DESCRIPTION
Standardizes the internal-request module on the shared design system and adds capabilities across the requester portal, agent queue, and admin setup.

## What changed
- **Foundations** — `requestTones` (status/priority/SLA/approval tones), `<RequestBadge>`, `.eyebrow` token; adopt `PageHeader` / `SectionCard` / `MetricCard` / `HrmsEmptyState` / `StandardTable` across the module.
- **New Request** — Category + Subcategory dropdowns, "Additional information" merged into the Request details card, and a Description **source selector** that auto-fills from the subcategory → category description while preserving manual edits.
- **Setup editors** — unified on list + side `Sheet`; **drag-and-drop reorder** (`@dnd-kit` + shared `SortableList` + reorder services) for categories, subcategories, routing rules, and templates; subcategory **description editing + full CRUD (delete)**.
- **Portal Documents/Announcements** — colour maps migrated to `toneClass`/`RequestBadge`; microcopy fixes.

## Verification
- `tsc --noEmit`, `eslint` (0 warnings), production build, and the internal-request service-boundary + RPC-contract + no-service-role checks all pass.
- `e2e/tickets.spec.ts` updated for the dropdown + description auto-fill (not executed in CI here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)