### PR TITLE
[codex] Add internal request ticket workspace

### DIFF
--- a/apps/hrms-web/src/components/layout/app-shell/internalRequestsShellConfig.ts
+++ b/apps/hrms-web/src/components/layout/app-shell/internalRequestsShellConfig.ts
@@ -21,6 +21,7 @@ const requestQueueRoles = new Set<AppRole>(ADMIN_ONLY);
 
 const INTERNAL_REQUESTS_ROUTE_CHROME: AppShellRouteChromeMatch[] = [
   { pattern: /^\/portal\/tickets\/new/, title: 'New Request', kicker: 'Submit and track internal support demand' },
+  { pattern: /^\/portal\/tickets\/[^/]+/, title: 'Ticket Workspace', kicker: 'Full request handling and accountability view' },
   { pattern: /^\/portal\/tickets$/, title: 'My Requests', kicker: 'Requester history and updates' },
   { pattern: /^\/portal\/queue/, title: 'Request Queue', kicker: 'Triage, assign, and resolve requests' },
   { pattern: /^\/portal\/history/, title: 'Request History', kicker: 'Resolved and closed requests' },

--- a/apps/hrms-web/src/main.tsx
+++ b/apps/hrms-web/src/main.tsx
@@ -13,19 +13,20 @@ function isChunkLoadError(err: unknown): boolean {
   );
 }
 
-function reloadOnce() {
-  const key = 'flc.hrms.chunk-reloaded';
+function reportChunkLoadError() {
+  const key = 'flc.hrms.chunk-load-error-reported';
   if (sessionStorage.getItem(key) === '1') return;
   sessionStorage.setItem(key, '1');
-  window.location.reload();
+  window.dispatchEvent(new CustomEvent('flc:chunk-load-error'));
+  console.warn('A lazy route chunk failed to load. Refresh manually when your current work is saved.');
 }
 
 window.addEventListener('error', (event) => {
-  if (isChunkLoadError(event.error ?? event.message)) reloadOnce();
+  if (isChunkLoadError(event.error ?? event.message)) reportChunkLoadError();
 });
 
 window.addEventListener('unhandledrejection', (event) => {
-  if (isChunkLoadError(event.reason)) reloadOnce();
+  if (isChunkLoadError(event.reason)) reportChunkLoadError();
 });
 
 createRoot(document.getElementById('root')!).render(

--- a/e2e/internal-requests-runtime.spec.ts
+++ b/e2e/internal-requests-runtime.spec.ts
@@ -193,6 +193,71 @@ test('Pending and Completed pages keep Completed by Owner separate from Closed',
   await expect(page.getByText('Awaiting requester confirmation')).toHaveCount(0);
 });
 
+test('Ticket Workspace preserves chat draft across browser tab focus changes', async ({ page, context }) => {
+  await page.route(`${SUPABASE_URL}/rest/v1/tickets*`, (route) => {
+    const accept = route.request().headers()['accept'] ?? '';
+    const wantsSingle = accept.includes('pgrst.object');
+    const workspaceTicket = ticketRow({
+      id: 'ticket-focus',
+      subject: 'Focus stability request',
+      status: 'in_progress',
+      description: 'Check that tab focus changes do not reload the workspace.',
+      assigned_to: '00000000-0000-0000-0000-000000000001',
+      assigned_to_name: 'Test Admin',
+      responsible_queue: 'Owner',
+      current_responsible_party: 'Owner',
+      next_action: 'Owner to complete request',
+      first_response_due_at: '2026-06-20T17:00:00.000Z',
+      resolution_due_at: '2026-06-21T17:00:00.000Z',
+    });
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(wantsSingle ? workspaceTicket : [workspaceTicket]),
+    });
+  });
+  await page.route(`${SUPABASE_URL}/rest/v1/ticket_activities*`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'activity-focus',
+          ticket_id: 'ticket-focus',
+          company_id: '00000000-0000-0000-0000-000000000099',
+          actor_id: '00000000-0000-0000-0000-000000000001',
+          actor_name: 'Test Admin',
+          event_type: 'comment_added',
+          message: 'Initial workspace message.',
+          metadata: {},
+          created_at: '2026-06-20T09:00:00.000Z',
+        },
+      ]),
+    });
+  });
+
+  const failures = collectRuntimeFailures(page);
+  await page.goto('/portal/tickets/ticket-focus?tab=chat', { waitUntil: 'domcontentloaded' });
+  await expectRouteStable(page, /focus stability request/i, failures);
+
+  const messageDraft = page.getByPlaceholder('Write a message');
+  await expect(messageDraft).toBeVisible();
+  await messageDraft.fill('Do not lose this draft');
+  const workspaceUrl = page.url();
+
+  const otherTab = await context.newPage();
+  await otherTab.goto('about:blank');
+  await otherTab.bringToFront();
+  await page.bringToFront();
+  await page.waitForTimeout(300);
+
+  await expect(page).toHaveURL(workspaceUrl);
+  await expect(messageDraft).toHaveValue('Do not lose this draft');
+  await expect(page.getByText(CRASH_TEXT)).toHaveCount(0);
+  await otherTab.close();
+  expect(failures).toEqual([]);
+});
+
 test('requester roles cannot access manager, queue, report, or setup routes', async ({ page }) => {
   const requesterProfile = {
     id: '00000000-0000-0000-0000-000000000001',

--- a/src/components/layout/app-shell/internalRequestsShellConfig.ts
+++ b/src/components/layout/app-shell/internalRequestsShellConfig.ts
@@ -29,6 +29,7 @@ const INTERNAL_REQUESTS_ROUTE_CHROME: AppShellRouteChromeMatch[] = [
   { pattern: /^\/portal\/?$/, title: 'Overview', kicker: 'Internal requests workspace' },
   { pattern: /^\/portal\/tickets\/new/, title: 'New Request', kicker: 'Submit and track internal support demand' },
   { pattern: /^\/portal\/tickets\/completed/, title: 'Completed Requests', kicker: 'Closed requester-confirmed requests' },
+  { pattern: /^\/portal\/tickets\/[^/]+/, title: 'Ticket Workspace', kicker: 'Full request handling and accountability view' },
   { pattern: /^\/portal\/tickets$/, title: 'Pending Requests', kicker: 'Requester actions and active updates' },
   { pattern: /^\/portal\/dashboard/, title: 'Manager Dashboard', kicker: 'SLA, workload, and bottleneck visibility' },
   { pattern: /^\/portal\/queue/, title: 'Pending / Active Requests', kicker: 'Triage, assign, and resolve requests' },

--- a/src/lib/ticketWorkspaceNavigation.test.ts
+++ b/src/lib/ticketWorkspaceNavigation.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildTicketWorkspacePath,
+  clearTicketWorkspaceReturnState,
+  getFallbackTicketListPath,
+  openTicketWorkspace,
+  readTicketWorkspaceReturnState,
+  saveTicketWorkspaceReturnState,
+} from './ticketWorkspaceNavigation';
+
+describe('ticketWorkspaceNavigation', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it('builds canonical workspace paths with optional tab selection', () => {
+    expect(buildTicketWorkspacePath('ticket-1')).toBe('/portal/tickets/ticket-1');
+    expect(buildTicketWorkspacePath('ticket/with space', 'chat')).toBe('/portal/tickets/ticket%2Fwith%20space?tab=chat');
+  });
+
+  it('serializes, reads, and clears return state', () => {
+    vi.setSystemTime(new Date('2026-06-19T12:00:00.000Z'));
+
+    saveTicketWorkspaceReturnState('ticket-1', {
+      source: 'queue',
+      path: '/portal/queue',
+      page: 2,
+      activeSavedView: 'my_queue',
+      filters: { statusFilter: 'active', searchTerm: 'fuel' },
+      scrollTop: 420,
+    });
+
+    expect(readTicketWorkspaceReturnState('ticket-1')).toEqual({
+      source: 'queue',
+      path: '/portal/queue',
+      page: 2,
+      activeSavedView: 'my_queue',
+      filters: { statusFilter: 'active', searchTerm: 'fuel' },
+      scrollTop: 420,
+      updatedAt: Date.parse('2026-06-19T12:00:00.000Z'),
+    });
+
+    clearTicketWorkspaceReturnState('ticket-1');
+    expect(readTicketWorkspaceReturnState('ticket-1')).toBeNull();
+  });
+
+  it('ignores malformed return state payloads', () => {
+    window.sessionStorage.setItem('internal-request-ticket-workspace:return:ticket-1', '{bad json');
+    expect(readTicketWorkspaceReturnState('ticket-1')).toBeNull();
+
+    window.sessionStorage.setItem('internal-request-ticket-workspace:return:ticket-1', JSON.stringify({ path: 42 }));
+    expect(readTicketWorkspaceReturnState('ticket-1')).toBeNull();
+  });
+
+  it('stores return state before navigating to a target tab', () => {
+    vi.setSystemTime(new Date('2026-06-19T12:30:00.000Z'));
+    const navigate = vi.fn();
+
+    openTicketWorkspace(
+      navigate,
+      'ticket-2',
+      {
+        source: 'pending',
+        path: '/portal/tickets',
+        filters: { statusFilter: 'attention' },
+      },
+      'attachments',
+    );
+
+    expect(navigate).toHaveBeenCalledWith('/portal/tickets/ticket-2?tab=attachments');
+    expect(readTicketWorkspaceReturnState('ticket-2')).toMatchObject({
+      source: 'pending',
+      path: '/portal/tickets',
+      filters: { statusFilter: 'attention' },
+      updatedAt: Date.parse('2026-06-19T12:30:00.000Z'),
+    });
+  });
+
+  it('chooses role-appropriate fallback list paths', () => {
+    expect(getFallbackTicketListPath(false, false)).toBe('/portal/tickets');
+    expect(getFallbackTicketListPath(false, true)).toBe('/portal/tickets/completed');
+    expect(getFallbackTicketListPath(true, false)).toBe('/portal/queue');
+    expect(getFallbackTicketListPath(true, true)).toBe('/portal/history');
+  });
+});

--- a/src/lib/ticketWorkspaceNavigation.ts
+++ b/src/lib/ticketWorkspaceNavigation.ts
@@ -11,7 +11,7 @@ export type TicketWorkspaceTab =
   | 'audit-trail';
 
 export interface TicketWorkspaceReturnState {
-  source: 'pending' | 'completed' | 'queue' | 'history';
+  source: 'pending' | 'completed' | 'queue' | 'history' | 'dashboard' | 'reports';
   path: string;
   scrollTop?: number;
   filters?: Record<string, unknown>;

--- a/src/lib/ticketWorkspaceNavigation.ts
+++ b/src/lib/ticketWorkspaceNavigation.ts
@@ -1,0 +1,69 @@
+import type { NavigateFunction } from 'react-router-dom';
+
+export type TicketWorkspaceTab =
+  | 'overview'
+  | 'details'
+  | 'chat'
+  | 'attachments'
+  | 'resolution'
+  | 'internal-notes'
+  | 'activity'
+  | 'audit-trail';
+
+export interface TicketWorkspaceReturnState {
+  source: 'pending' | 'completed' | 'queue' | 'history';
+  path: string;
+  scrollTop?: number;
+  filters?: Record<string, unknown>;
+  page?: number;
+  activeSavedView?: string;
+  updatedAt: number;
+}
+
+const RETURN_STATE_PREFIX = 'internal-request-ticket-workspace:return:';
+
+export function buildTicketWorkspacePath(ticketId: string, tab?: TicketWorkspaceTab) {
+  const encodedTicketId = encodeURIComponent(ticketId);
+  return `/portal/tickets/${encodedTicketId}${tab ? `?tab=${encodeURIComponent(tab)}` : ''}`;
+}
+
+export function saveTicketWorkspaceReturnState(ticketId: string, state: Omit<TicketWorkspaceReturnState, 'updatedAt'>) {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.setItem(
+    `${RETURN_STATE_PREFIX}${ticketId}`,
+    JSON.stringify({ ...state, updatedAt: Date.now() } satisfies TicketWorkspaceReturnState),
+  );
+}
+
+export function readTicketWorkspaceReturnState(ticketId: string): TicketWorkspaceReturnState | null {
+  if (typeof window === 'undefined') return null;
+  const raw = window.sessionStorage.getItem(`${RETURN_STATE_PREFIX}${ticketId}`);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as TicketWorkspaceReturnState;
+    if (!parsed || typeof parsed.path !== 'string' || typeof parsed.source !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearTicketWorkspaceReturnState(ticketId: string) {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.removeItem(`${RETURN_STATE_PREFIX}${ticketId}`);
+}
+
+export function openTicketWorkspace(
+  navigate: NavigateFunction,
+  ticketId: string,
+  state: Omit<TicketWorkspaceReturnState, 'updatedAt'>,
+  tab?: TicketWorkspaceTab,
+) {
+  saveTicketWorkspaceReturnState(ticketId, state);
+  navigate(buildTicketWorkspacePath(ticketId, tab));
+}
+
+export function getFallbackTicketListPath(canManageQueue: boolean, closed = false) {
+  if (canManageQueue) return closed ? '/portal/history' : '/portal/queue';
+  return closed ? '/portal/tickets/completed' : '/portal/tickets';
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -411,12 +411,10 @@ if (!shouldRedirectInviteToSignup()) {
 }
 
 // After a redeploy, hashed asset filenames change. Any tab that was open
-// before the deploy still holds the old index.html → when React tries to
-// lazy-load a route chunk it gets a 404 and throws:
-//   "Failed to fetch dynamically imported module: .../assets/xxx.js"
-// We catch that one specific error and do a single auto-reload so users
-// silently pick up the new build instead of seeing an error page. Uses
-// sessionStorage to prevent an infinite loop if the reload itself fails.
+// before the deploy still holds the old index.html and a lazy route chunk may
+// fail to load. Do not auto-reload here: active ticket workspaces can contain
+// drafts and workflow state. Report once so UI/runtime monitoring can surface a
+// manual refresh path without destroying in-progress work.
 function isChunkLoadError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err ?? '');
   return (
@@ -425,17 +423,18 @@ function isChunkLoadError(err: unknown): boolean {
     || /ChunkLoadError/i.test(msg)
   );
 }
-function reloadOnce() {
-  const key = 'flc.chunk-reloaded';
+function reportChunkLoadError() {
+  const key = 'flc.chunk-load-error-reported';
   if (sessionStorage.getItem(key) === '1') return;
   sessionStorage.setItem(key, '1');
-  window.location.reload();
+  window.dispatchEvent(new CustomEvent('flc:chunk-load-error'));
+  console.warn('A lazy route chunk failed to load. Refresh manually when your current work is saved.');
 }
 window.addEventListener('error', (e) => {
-  if (isChunkLoadError(e.error ?? e.message)) reloadOnce();
+  if (isChunkLoadError(e.error ?? e.message)) reportChunkLoadError();
 });
 window.addEventListener('unhandledrejection', (e) => {
-  if (isChunkLoadError(e.reason)) reloadOnce();
+  if (isChunkLoadError(e.reason)) reportChunkLoadError();
 });
 
 export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -57,6 +57,7 @@ const CustomerServiceLayout = lazy(() => import("./components/layout/CustomerSer
 const MyTickets = lazy(() => import("./pages/tickets/MyTickets"));
 const CompletedRequests = lazy(() => import("./pages/tickets/CompletedRequests"));
 const NewTicket = lazy(() => import("./pages/tickets/NewTicket"));
+const TicketWorkspace = lazy(() => import("./pages/tickets/TicketWorkspace"));
 const ManagerDashboard = lazy(() => import("./pages/tickets/ManagerDashboard"));
 const RequestReports = lazy(() => import("./pages/tickets/RequestReports"));
 const RequestQueue = lazy(() => import("./pages/tickets/RequestQueue"));
@@ -318,6 +319,7 @@ const router = createBrowserRouter([
       { path: "tickets", element: <S><R scope="Pending Requests"><MyTickets /></R></S> },
       { path: "tickets/completed", element: <S><R scope="Completed Requests"><CompletedRequests /></R></S> },
       { path: "tickets/new", element: <S><R scope="New Ticket"><NewTicket /></R></S> },
+      { path: "tickets/:ticketId", element: <S><R scope="Ticket Workspace"><TicketWorkspace /></R></S> },
       { path: "dashboard", element: <RequireRole roles={PORTAL_QUEUE_ROLES} section="Platform"><S><R scope="Manager Dashboard"><ManagerDashboard /></R></S></RequireRole> },
       { path: "queue", element: <RequireRole roles={PORTAL_QUEUE_ROLES} section="Platform"><S><R scope="Pending / Active Requests"><RequestQueue /></R></S></RequireRole> },
       { path: "history", element: <RequireRole roles={PORTAL_QUEUE_ROLES} section="Platform"><S><R scope="Completed Requests"><RequestHistory /></R></S></RequireRole> },

--- a/src/pages/tickets/CompletedRequests.tsx
+++ b/src/pages/tickets/CompletedRequests.tsx
@@ -1,50 +1,37 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
-import { AlertCircle, Archive, MessageSquare, RefreshCcw, RotateCcw, Search } from 'lucide-react';
+import { AlertCircle, Archive, MessageSquare, RefreshCcw, Search } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '@/contexts/AuthContext';
 import { STALE } from '@/lib/queryClient';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { PageHeader } from '@/components/shared/PageHeader';
 import { HrmsEmptyState } from '@/components/shared/HrmsEmptyState';
 import { StandardTable, type StandardTableColumn } from '@/components/shared/StandardTable';
 import { TableSkeleton } from '@/components/ui/TableSkeleton';
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { RequestPriorityBadge, RequestStatusBadge } from '@/components/tickets/RequestBadge';
-import { TicketActivityList } from '@/components/tickets/TicketActivityList';
-import { TicketAttachmentList } from '@/components/tickets/TicketAttachmentList';
-import { TicketChatPanel } from '@/components/tickets/TicketChatPanel';
-import { TicketSlaSummary } from '@/components/tickets/TicketSlaSummary';
 import { useRequestCategories } from '@/hooks/useRequestCategories';
 import { useTicketsRealtime } from '@/hooks/useTicketsRealtime';
 import { getRequestCategoryLabel } from '@/lib/requestCategories';
+import { openTicketWorkspace } from '@/lib/ticketWorkspaceNavigation';
 import {
   listMyTickets,
   listTicketChatSummaries,
-  listTicketActivity,
-  markTicketChatRead,
-  reopenTicketByRequester,
   type RequestTicketRecord,
-  type TicketActivityRecord,
   type TicketChatSummary,
 } from '@/services/ticketService';
-import { listAttachmentsForTickets, type TicketAttachmentRecord } from '@flc/platform-services';
 
 export default function CompletedRequests() {
   const { user } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const { categories } = useRequestCategories(user?.company_id, true);
   const [searchTerm, setSearchTerm] = useState('');
-  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
-  const [chatTicketId, setChatTicketId] = useState<string | null>(null);
   const [chatSummariesByTicket, setChatSummariesByTicket] = useState<Record<string, TicketChatSummary>>({});
-  const [reopenTargetId, setReopenTargetId] = useState<string | null>(null);
-  const [reopenReason, setReopenReason] = useState('');
-  const [savingReopen, setSavingReopen] = useState(false);
   const completedKey = ['completed-requests', user?.id, user?.company_id] as const;
 
   const { data, isLoading, error } = useQuery({
@@ -54,16 +41,10 @@ export default function CompletedRequests() {
       if (fetchError) throw fetchError;
       const closedTickets = (ticketRows ?? []).filter((ticket) => ticket.status === 'closed');
       const ticketIds = closedTickets.map((ticket) => ticket.id);
-      const [{ data: activityData }, { data: attachmentData }, { data: chatSummaryData }] = await Promise.all([
-        listTicketActivity(ticketIds, user!.company_id),
-        listAttachmentsForTickets(ticketIds, user!.company_id),
-        listTicketChatSummaries(ticketIds, user!.id, user!.company_id),
-      ]);
+      const { data: chatSummaryData } = await listTicketChatSummaries(ticketIds, user!.id, user!.company_id);
       setChatSummariesByTicket(chatSummaryData ?? {});
       return {
         tickets: closedTickets,
-        activitiesByTicket: activityData ?? {} as Record<string, TicketActivityRecord[]>,
-        attachmentsByTicket: attachmentData ?? {} as Record<string, TicketAttachmentRecord[]>,
       };
     },
     enabled: !!user,
@@ -74,8 +55,6 @@ export default function CompletedRequests() {
   useTicketsRealtime({ companyId: user?.company_id, scope: 'completed-requests', onChange: refresh });
 
   const tickets = useMemo(() => data?.tickets ?? [], [data?.tickets]);
-  const activitiesByTicket = useMemo(() => data?.activitiesByTicket ?? {}, [data?.activitiesByTicket]);
-  const attachmentsByTicket = useMemo(() => data?.attachmentsByTicket ?? {}, [data?.attachmentsByTicket]);
 
   const filteredTickets = useMemo(() => {
     const query = searchTerm.trim().toLowerCase();
@@ -88,38 +67,13 @@ export default function CompletedRequests() {
     ].filter(Boolean).join(' ').toLowerCase().includes(query));
   }, [categories, searchTerm, tickets]);
 
-  const selectedTicket = filteredTickets.find((ticket) => ticket.id === selectedTicketId) ?? null;
-  const chatTicket = filteredTickets.find((ticket) => ticket.id === chatTicketId) ?? null;
-
-  const handleOpenChat = useCallback(async (ticketId: string) => {
-    if (!user) return;
-    setChatTicketId(ticketId);
-    await markTicketChatRead(ticketId, { userId: user.id, companyId: user.company_id });
-    setChatSummariesByTicket((current) => ({
-      ...current,
-      [ticketId]: {
-        ticket_id: ticketId,
-        message_count: current[ticketId]?.message_count ?? 0,
-        unread_count: 0,
-        latest_message_at: current[ticketId]?.latest_message_at ?? null,
-      },
-    }));
-  }, [user]);
-
-  const handleReopen = async () => {
-    if (!user || !reopenTargetId) return;
-    setSavingReopen(true);
-    const { error: reopenError } = await reopenTicketByRequester(
-      reopenTargetId,
-      { reason: reopenReason },
-      { userId: user.id, companyId: user.company_id },
-    );
-    setSavingReopen(false);
-    if (reopenError) return;
-    setReopenTargetId(null);
-    setReopenReason('');
-    await queryClient.invalidateQueries({ queryKey: completedKey });
-  };
+  const handleOpenChat = useCallback((ticketId: string) => {
+    openTicketWorkspace(navigate, ticketId, {
+      source: 'completed',
+      path: `${location.pathname}${location.search}`,
+      filters: { searchTerm },
+    }, 'chat');
+  }, [location.pathname, location.search, navigate, searchTerm]);
 
   const columns = useMemo<StandardTableColumn<RequestTicketRecord>[]>(() => [
     {
@@ -215,106 +169,16 @@ export default function CompletedRequests() {
           columns={columns}
           rowKey="id"
           hideSearch
-          mobileLayout="cards"
+          mobileLayout="table"
           emptyMessage="No completed requests match your search."
-          onRowClick={(ticket) => setSelectedTicketId(ticket.id)}
+          onRowClick={(ticket) => openTicketWorkspace(navigate, ticket.id, {
+            source: 'completed',
+            path: `${location.pathname}${location.search}`,
+            filters: { searchTerm },
+          })}
         />
       )}
 
-      <Sheet open={!!selectedTicket} onOpenChange={(open) => { if (!open) setSelectedTicketId(null); }}>
-        <SheetContent side="right" className="w-full gap-0 overflow-y-auto p-0 sm:max-w-xl">
-          {selectedTicket && (
-            <>
-              <SheetHeader className="space-y-2 border-b border-border px-5 py-4 text-left">
-                <div className="flex flex-wrap items-center gap-1.5">
-                  <RequestStatusBadge status={selectedTicket.status} />
-                  <RequestPriorityBadge priority={selectedTicket.priority} />
-                </div>
-                <SheetTitle className="text-base leading-6">{selectedTicket.subject}</SheetTitle>
-                <SheetDescription>{getRequestCategoryLabel(selectedTicket.category, categories)}</SheetDescription>
-              </SheetHeader>
-              <div className="space-y-3 px-5 py-4">
-                <div className="rounded-md border bg-background px-3 py-2">
-                  <p className="eyebrow mb-1">Description</p>
-                  <p className="whitespace-pre-line text-sm leading-5 text-foreground">{selectedTicket.description}</p>
-                </div>
-                <TicketSlaSummary ticket={selectedTicket} />
-                {selectedTicket.resolution_note && (
-                  <div className="rounded-md border border-border bg-secondary/30 px-3 py-2">
-                    <p className="eyebrow">Resolution note</p>
-                    <p className="mt-1 text-sm leading-5 text-foreground">{selectedTicket.resolution_note}</p>
-                  </div>
-                )}
-                <TicketAttachmentList attachments={attachmentsByTicket[selectedTicket.id] ?? []} />
-                <TicketChatPanel
-                  activities={activitiesByTicket[selectedTicket.id] ?? []}
-                  currentUserId={user?.id}
-                  draft=""
-                  saving={false}
-                  onDraftChange={() => undefined}
-                  onSend={() => undefined}
-                  readOnly
-                />
-                <Button type="button" size="sm" variant="outline" className="w-full gap-1.5" onClick={() => setReopenTargetId(selectedTicket.id)}>
-                  <RotateCcw className="h-3.5 w-3.5" />
-                  Reopen request
-                </Button>
-                <TicketActivityList activities={activitiesByTicket[selectedTicket.id] ?? []} />
-              </div>
-            </>
-          )}
-        </SheetContent>
-      </Sheet>
-
-      <Sheet open={!!chatTicket} onOpenChange={(open) => { if (!open) setChatTicketId(null); }}>
-        <SheetContent side="right" className="w-full gap-0 overflow-y-auto p-0 sm:max-w-md">
-          {chatTicket && (
-            <>
-              <SheetHeader className="space-y-1 border-b border-border px-5 py-4 text-left">
-                <SheetTitle className="text-base leading-6">Discussion</SheetTitle>
-                <SheetDescription>{chatTicket.subject}</SheetDescription>
-              </SheetHeader>
-              <div className="px-5 py-4">
-                <TicketChatPanel
-                  activities={activitiesByTicket[chatTicket.id] ?? []}
-                  currentUserId={user?.id}
-                  draft=""
-                  saving={false}
-                  onDraftChange={() => undefined}
-                  onSend={() => undefined}
-                  readOnly
-                />
-              </div>
-            </>
-          )}
-        </SheetContent>
-      </Sheet>
-
-      <Dialog open={!!reopenTargetId} onOpenChange={(open) => {
-        if (!open) {
-          setReopenTargetId(null);
-          setReopenReason('');
-        }
-      }}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Reopen request</DialogTitle>
-            <DialogDescription>Provide a reason. Reopened requests return to Pending / Active Requests.</DialogDescription>
-          </DialogHeader>
-          <Textarea
-            value={reopenReason}
-            onChange={(event) => setReopenReason(event.target.value)}
-            rows={3}
-            placeholder="Reason for reopening"
-          />
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setReopenTargetId(null)}>Cancel</Button>
-            <Button onClick={() => void handleReopen()} disabled={savingReopen || !reopenReason.trim()}>
-              {savingReopen ? 'Reopening...' : 'Reopen'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/src/pages/tickets/ManagerDashboard.tsx
+++ b/src/pages/tickets/ManagerDashboard.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
+import { useNavigate } from 'react-router-dom';
 import {
   AlertTriangle,
   Archive,
@@ -22,6 +23,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { RequestPriorityBadge, RequestStatusBadge } from '@/components/tickets/RequestBadge';
 import { useRequestCategories } from '@/hooks/useRequestCategories';
 import { getRequestCategoryLabel } from '@/lib/requestCategories';
+import { openTicketWorkspace } from '@/lib/ticketWorkspaceNavigation';
 import { getRequestManagementDashboard } from '@/services/requestManagementService';
 
 function formatDuration(ms: number | null) {
@@ -49,6 +51,7 @@ function BarRow({ label, value, max, tone = 'bg-primary' }: { label: string; val
 
 export default function ManagerDashboard() {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const { categories } = useRequestCategories(user?.company_id, true);
 
   const { data, isLoading, error } = useQuery({
@@ -112,7 +115,16 @@ export default function ManagerDashboard() {
                 ) : (
                   <div className="divide-y divide-border">
                     {data.oldest_pending.map((ticket) => (
-                      <div key={ticket.id} className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_160px_140px] md:items-center">
+                      <button
+                        key={ticket.id}
+                        type="button"
+                        className="grid w-full gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40 focus:outline-none focus:ring-2 focus:ring-primary/40 md:grid-cols-[minmax(0,1fr)_160px_140px] md:items-center"
+                        onClick={() => openTicketWorkspace(navigate, ticket.id, {
+                          source: 'dashboard',
+                          path: '/portal/dashboard',
+                          scrollTop: window.scrollY,
+                        })}
+                      >
                         <div className="min-w-0">
                           <p className="truncate text-sm font-medium text-foreground">{ticket.subject}</p>
                           <p className="truncate text-xs text-muted-foreground">
@@ -126,7 +138,7 @@ export default function ManagerDashboard() {
                         <div className="text-xs text-muted-foreground md:text-right">
                           {formatDistanceToNow(new Date(ticket.created_at), { addSuffix: true })}
                         </div>
-                      </div>
+                      </button>
                     ))}
                   </div>
                 )}

--- a/src/pages/tickets/MyTickets.tsx
+++ b/src/pages/tickets/MyTickets.tsx
@@ -1,14 +1,12 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { STALE } from '@/lib/queryClient';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
 import {
   AlertCircle,
-  CalendarDays,
   CheckCircle2,
   Inbox,
-  Loader2,
   MessageSquare,
   Plus,
   RefreshCcw,
@@ -26,103 +24,35 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { PageHeader } from '@/components/shared/PageHeader';
 import { MetricCard } from '@/components/shared/MetricCard';
 import { HrmsEmptyState } from '@/components/shared/HrmsEmptyState';
 import { StandardTable, type StandardTableColumn } from '@/components/shared/StandardTable';
 import { TableSkeleton } from '@/components/ui/TableSkeleton';
-import { RequestBadge, RequestPriorityBadge, RequestStatusBadge } from '@/components/tickets/RequestBadge';
-import { TicketActivityList } from '@/components/tickets/TicketActivityList';
-import { TicketAttachmentList } from '@/components/tickets/TicketAttachmentList';
-import { TicketApprovalSummary } from '@/components/tickets/TicketApprovalSummary';
-import { TicketSlaSummary } from '@/components/tickets/TicketSlaSummary';
+import { RequestPriorityBadge, RequestStatusBadge } from '@/components/tickets/RequestBadge';
 import { useRequestCategories } from '@/hooks/useRequestCategories';
-import { useRequestFormFields } from '@/hooks/useRequestFormFields';
-import { useRequestSubcategories } from '@/hooks/useRequestSubcategories';
 import { useTicketsRealtime } from '@/hooks/useTicketsRealtime';
-import { usePersistedDraftMap } from '@/hooks/usePersistedDraftMap';
 import { getRequestCategoryLabel } from '@/lib/requestCategories';
+import { openTicketWorkspace } from '@/lib/ticketWorkspaceNavigation';
 
 import {
-  formatDueDate,
-  customFieldEntries,
-} from '@/lib/requestFormatters';
-import {
-  addTicketComment,
-  closeTicketByRequester,
-  cancelMyTicket,
   listTicketChatSummaries,
   listMyTickets,
-  listTicketActivity,
-  markTicketChatRead,
-  submitRequesterTicketUpdate,
   type RequestTicketRecord,
-  type TicketActivityRecord,
   type TicketChatSummary,
 } from '@/services/ticketService';
-import { listAttachmentsForTickets, uploadTicketAttachment, type TicketAttachmentRecord } from '@flc/platform-services';
-import { TicketChatPanel } from '@/components/tickets/TicketChatPanel';
 
 type MyStatusFilter = 'all' | 'in_progress' | 'attention' | 'cancelled';
 
 export default function MyTickets() {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const { categories } = useRequestCategories(user?.company_id, true);
-  useRequestSubcategories(user?.company_id, { includeInactive: true });
-  const { fields: formFields } = useRequestFormFields(user?.company_id, { includeInactive: true });
-  const [error, setError] = useState<string | null>(null);
-  const [commentDrafts, setCommentDrafts, clearCommentDraft] = usePersistedDraftMap(
-    'my-tickets:comment',
-    user?.company_id,
-    user?.id,
-  );
-  const [savingCommentId, setSavingCommentId] = useState<string | null>(null);
-  const [cancellingTicketId, setCancellingTicketId] = useState<string | null>(null);
-  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
-  const [chatTicketId, setChatTicketId] = useState<string | null>(null);
   const [chatSummariesByTicket, setChatSummariesByTicket] = useState<Record<string, TicketChatSummary>>({});
-  const [closeTargetId, setCloseTargetId] = useState<string | null>(null);
-  const [closeConfirmed, setCloseConfirmed] = useState(false);
-  const [satisfactionRating, setSatisfactionRating] = useState('5');
-  const [closureFeedback, setClosureFeedback] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState<MyStatusFilter>('all');
-
-  const customFieldLabelMap = useMemo(
-    () => Object.fromEntries(formFields.map((field) => [`${field.category_key}:${field.key}`, field.label])),
-    [formFields],
-  );
 
   const myTicketsKey = ['my-tickets', user?.id, user?.company_id] as const;
 
@@ -133,16 +63,10 @@ export default function MyTickets() {
       if (fetchError) throw new Error(fetchError.message || 'Unable to load requests.');
       const nextTickets = data ?? [];
       const ticketIds = nextTickets.map((t) => t.id);
-      const [{ data: activityData }, { data: attachmentData }, { data: chatSummaryData }] = await Promise.all([
-        listTicketActivity(ticketIds, user!.company_id),
-        listAttachmentsForTickets(ticketIds, user!.company_id),
-        listTicketChatSummaries(ticketIds, user!.id, user!.company_id),
-      ]);
+      const { data: chatSummaryData } = await listTicketChatSummaries(ticketIds, user!.id, user!.company_id);
       setChatSummariesByTicket(chatSummaryData ?? {});
       return {
         tickets: nextTickets,
-        activitiesByTicket: activityData ?? {} as Record<string, TicketActivityRecord[]>,
-        attachmentsByTicket: attachmentData ?? {} as Record<string, TicketAttachmentRecord[]>,
       };
     },
     enabled: !!user,
@@ -150,15 +74,11 @@ export default function MyTickets() {
   });
 
   const tickets = useMemo(() => ticketsData?.tickets ?? [], [ticketsData]);
-  const activitiesByTicket = useMemo(() => ticketsData?.activitiesByTicket ?? {}, [ticketsData]);
-  const attachmentsByTicket = useMemo(() => ticketsData?.attachmentsByTicket ?? {}, [ticketsData]);
-  const displayError = error ?? (
-    queryError instanceof Error
-      ? queryError.message
-      : queryError
-        ? 'Unable to load requests.'
-        : null
-  );
+  const displayError = queryError instanceof Error
+    ? queryError.message
+    : queryError
+      ? 'Unable to load requests.'
+      : null;
 
   // Seed effect removed: usePersistedDraftMap returns the same shape and
   // every consumer already falls back to '' via `commentDrafts[id] ?? ''`,
@@ -184,120 +104,13 @@ export default function MyTickets() {
     onChange: refreshTickets,
   });
 
-  const handleAddComment = async (ticketId: string) => {
-    if (!user) return;
-    const message = commentDrafts[ticketId]?.trim() ?? '';
-    if (!message) return;
-
-    setSavingCommentId(ticketId);
-    setError(null);
-    const target = tickets.find((ticket) => ticket.id === ticketId);
-    const { error: commentError } = target?.status === 'pending_requester'
-      ? await submitRequesterTicketUpdate(ticketId, { message }, { userId: user.id, companyId: user.company_id })
-      : await addTicketComment(ticketId, { message }, { userId: user.id, companyId: user.company_id });
-    setSavingCommentId(null);
-
-    if (commentError) {
-      setError(commentError.message || 'Unable to add comment.');
-      return;
-    }
-
-    clearCommentDraft(ticketId);
-    // The activity timeline is fetched as part of the myTicketsKey query —
-    // invalidate so the new comment shows up without manual state plumbing.
-    await queryClient.invalidateQueries({ queryKey: myTicketsKey });
-  };
-
-  const handleOpenChat = useCallback(async (ticketId: string) => {
-    if (!user) return;
-    setChatTicketId(ticketId);
-    await markTicketChatRead(ticketId, { userId: user.id, companyId: user.company_id });
-    setChatSummariesByTicket((current) => ({
-      ...current,
-      [ticketId]: {
-        ticket_id: ticketId,
-        message_count: current[ticketId]?.message_count ?? 0,
-        unread_count: 0,
-        latest_message_at: current[ticketId]?.latest_message_at ?? null,
-      },
-    }));
-  }, [user]);
-
-  const handleChatFilesSelected = async (ticketId: string, files: File[]) => {
-    if (!user || files.length === 0) return;
-    setSavingCommentId(ticketId);
-    setError(null);
-    const results = await Promise.all(files.map((file) => uploadTicketAttachment(file, ticketId, user.company_id, user.id)));
-    const failed = results.filter((result) => result.error);
-    const uploadedNames = files.filter((_, index) => !results[index].error).map((file) => file.name);
-    if (uploadedNames.length > 0) {
-      await addTicketComment(
-        ticketId,
-        { message: `Attached ${uploadedNames.length} file${uploadedNames.length === 1 ? '' : 's'}.`, attachmentNames: uploadedNames },
-        { userId: user.id, companyId: user.company_id },
-      );
-    }
-    if (failed.length > 0) setError(`${failed.length} attachment${failed.length === 1 ? '' : 's'} failed to upload.`);
-    setSavingCommentId(null);
-    await queryClient.invalidateQueries({ queryKey: myTicketsKey });
-  };
-
-  const handleCloseTicket = async () => {
-    if (!user) return;
-    const ticketId = closeTargetId;
-    if (!ticketId) return;
-    setSavingCommentId(ticketId);
-    setError(null);
-    const { error: closeError } = await closeTicketByRequester(
-      ticketId,
-      {
-        confirmedResolved: closeConfirmed,
-        satisfactionRating: Number(satisfactionRating),
-        feedbackComment: closureFeedback,
-      },
-      { userId: user.id, companyId: user.company_id },
-    );
-    setSavingCommentId(null);
-    if (closeError) {
-      setError(closeError.message || 'Unable to close request.');
-      return;
-    }
-    setCloseTargetId(null);
-    setCloseConfirmed(false);
-    setSatisfactionRating('5');
-    setClosureFeedback('');
-    await queryClient.invalidateQueries({ queryKey: myTicketsKey });
-  };
-
-  const handleCancelTicket = async (ticketId: string) => {
-    if (!user) return;
-    setCancellingTicketId(ticketId);
-    setError(null);
-
-    const { data, error: cancelError } = await cancelMyTicket(
-      ticketId,
-      { reason: 'Cancelled by requester.' },
-      { userId: user.id, companyId: user.company_id },
-    );
-
-    setCancellingTicketId(null);
-    if (cancelError || !data) {
-      setError(cancelError?.message || 'Unable to cancel request.');
-      return;
-    }
-
-    queryClient.setQueryData<typeof ticketsData>(myTicketsKey, (old) => old ? {
-      ...old,
-      tickets: old.tickets.map((ticket) => ticket.id === ticketId ? {
-        ...ticket,
-        status: data.status,
-        resolved_at: data.resolved_at,
-        resolution_note: data.resolution_note,
-        updated_at: data.updated_at,
-      } : ticket),
-    } : old);
-    refreshTickets();
-  };
+  const handleOpenChat = useCallback((ticketId: string) => {
+    openTicketWorkspace(navigate, ticketId, {
+      source: 'pending',
+      path: `${location.pathname}${location.search}`,
+      filters: { searchTerm, statusFilter },
+    }, 'chat');
+  }, [location.pathname, location.search, navigate, searchTerm, statusFilter]);
 
 
   // ── Derived state ─────────────────────────────────────────────────────────
@@ -334,14 +147,6 @@ export default function MyTickets() {
     });
   }, [tickets, searchTerm, statusFilter, categories]);
 
-  const selectedTicket = useMemo(
-    () => filteredTickets.find((ticket) => ticket.id === selectedTicketId) ?? null,
-    [filteredTickets, selectedTicketId],
-  );
-  const chatTicket = useMemo(
-    () => filteredTickets.find((ticket) => ticket.id === chatTicketId) ?? null,
-    [chatTicketId, filteredTickets],
-  );
 
   const columns = useMemo<StandardTableColumn<RequestTicketRecord>[]>(() => [
     {
@@ -440,9 +245,6 @@ export default function MyTickets() {
     { key: 'cancelled', label: 'Cancelled', value: counts.cancelled, icon: XCircle, tone: 'slate' },
   ];
 
-  const selectedExtraFields = selectedTicket ? customFieldEntries(selectedTicket, customFieldLabelMap) : [];
-  const selectedCanCancel = selectedTicket?.status === 'open' && !selectedTicket.assigned_to;
-
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
@@ -533,236 +335,16 @@ export default function MyTickets() {
           columns={columns}
           rowKey="id"
           hideSearch
-          mobileLayout="cards"
+          mobileLayout="table"
           emptyMessage="No requests match your search or filter."
-          onRowClick={(ticket) => setSelectedTicketId(ticket.id)}
+          onRowClick={(ticket) => openTicketWorkspace(navigate, ticket.id, {
+            source: 'pending',
+            path: `${location.pathname}${location.search}`,
+            filters: { searchTerm, statusFilter },
+          })}
         />
       )}
 
-      {/* Request detail drawer */}
-      <Sheet
-        open={!!selectedTicket}
-        onOpenChange={(open) => {
-          if (!open) setSelectedTicketId(null);
-        }}
-      >
-        <SheetContent side="right" className="w-full gap-0 overflow-y-auto p-0 sm:max-w-xl">
-          {selectedTicket && (
-            <>
-              <SheetHeader className="space-y-2 border-b border-border px-5 py-4 text-left">
-                <div className="flex flex-wrap items-center gap-1.5">
-                  <RequestStatusBadge status={selectedTicket.status} />
-                  <RequestPriorityBadge priority={selectedTicket.priority} />
-                  {selectedTicket.requested_due_date && (
-                    <RequestBadge
-                      tone="slate"
-                      icon={CalendarDays}
-                      label={`Due ${formatDueDate(selectedTicket.requested_due_date)}`}
-                    />
-                  )}
-                </div>
-                <SheetTitle className="text-base leading-6">{selectedTicket.subject}</SheetTitle>
-                <SheetDescription>
-                  {getRequestCategoryLabel(selectedTicket.category, categories)}
-                  {' · Submitted '}
-                  {formatDistanceToNow(new Date(selectedTicket.created_at), { addSuffix: true })}
-                  {selectedTicket.vso_number ? ` · VSO ${selectedTicket.vso_number}` : ''}
-                </SheetDescription>
-              </SheetHeader>
-
-              <div className="space-y-3 px-5 py-4">
-                <div className="rounded-md border bg-background px-3 py-2">
-                  <p className="eyebrow mb-1">Description</p>
-                  <p className="whitespace-pre-line text-sm leading-5 text-foreground">{selectedTicket.description}</p>
-                </div>
-
-                <TicketSlaSummary ticket={selectedTicket} />
-                <TicketApprovalSummary ticket={selectedTicket} />
-
-                {(selectedTicket.desired_outcome || selectedTicket.business_impact) && (
-                  <div className="grid gap-2 sm:grid-cols-2">
-                    {selectedTicket.desired_outcome && (
-                      <div className="rounded-md border border-border bg-background px-3 py-2">
-                        <p className="eyebrow flex items-center gap-1.5">
-                          <CheckCircle2 className="h-3 w-3" />
-                          Desired outcome
-                        </p>
-                        <p className="mt-1 text-sm leading-5 text-foreground">{selectedTicket.desired_outcome}</p>
-                      </div>
-                    )}
-                    {selectedTicket.business_impact && (
-                      <div className="rounded-md border border-border bg-background px-3 py-2">
-                        <p className="eyebrow">Business impact</p>
-                        <p className="mt-1 text-sm leading-5 text-foreground">{selectedTicket.business_impact}</p>
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {selectedExtraFields.length > 0 && (
-                  <div className="rounded-md border border-border bg-background px-3 py-2">
-                    <p className="eyebrow">Additional details</p>
-                    <div className="mt-1.5 grid gap-2 sm:grid-cols-2">
-                      {selectedExtraFields.map((field) => (
-                        <div key={field.key} className="min-w-0">
-                          <p className="text-xs text-muted-foreground">{field.label}</p>
-                          <p className="truncate text-sm text-foreground">{field.value}</p>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {selectedTicket.resolution_note && (
-                  <div className="rounded-md border border-border bg-secondary/30 px-3 py-2">
-                    <p className="eyebrow">Resolution note</p>
-                    <p className="mt-1 text-sm leading-5 text-foreground">{selectedTicket.resolution_note}</p>
-                  </div>
-                )}
-
-                <TicketAttachmentList attachments={attachmentsByTicket[selectedTicket.id] ?? []} />
-
-                {selectedTicket.status !== 'closed' && selectedTicket.status !== 'cancelled' && (
-                  <div className="space-y-2 rounded-md border border-border bg-background px-3 py-2.5">
-                    <p className="eyebrow flex items-center gap-1.5">
-                      <MessageSquare className="h-3 w-3" />
-                      Discussion
-                    </p>
-                    <TicketChatPanel
-                      activities={activitiesByTicket[selectedTicket.id] ?? []}
-                      currentUserId={user?.id}
-                      draft={commentDrafts[selectedTicket.id] ?? ''}
-                      saving={savingCommentId === selectedTicket.id}
-                      onDraftChange={(value) => setCommentDrafts((current) => ({ ...current, [selectedTicket.id]: value }))}
-                      onSend={() => void handleAddComment(selectedTicket.id)}
-                      onAttachFiles={(files) => void handleChatFilesSelected(selectedTicket.id, files)}
-                    />
-                  </div>
-                )}
-
-                {selectedTicket.status === 'completed_by_owner' && (
-                  <Button
-                    type="button"
-                    size="sm"
-                    className="w-full"
-                    disabled={savingCommentId === selectedTicket.id}
-                    onClick={() => setCloseTargetId(selectedTicket.id)}
-                  >
-                    Close request
-                  </Button>
-                )}
-
-                <TicketActivityList activities={activitiesByTicket[selectedTicket.id] ?? []} />
-
-                {selectedCanCancel && (
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="w-full gap-1.5 text-destructive hover:text-destructive"
-                        disabled={cancellingTicketId === selectedTicket.id}
-                      >
-                        {cancellingTicketId === selectedTicket.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <XCircle className="h-3.5 w-3.5" />}
-                        Cancel request
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Cancel request?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          This request is still open and unassigned. Cancelling it will close the request and remove it from the active queue.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Keep request</AlertDialogCancel>
-                        <AlertDialogAction
-                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                          onClick={() => void handleCancelTicket(selectedTicket.id)}
-                        >
-                          Cancel request
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                )}
-              </div>
-            </>
-          )}
-        </SheetContent>
-      </Sheet>
-
-      <Sheet open={!!chatTicket} onOpenChange={(open) => { if (!open) setChatTicketId(null); }}>
-        <SheetContent side="right" className="w-full gap-0 overflow-y-auto p-0 sm:max-w-md">
-          {chatTicket && (
-            <>
-              <SheetHeader className="space-y-1 border-b border-border px-5 py-4 text-left">
-                <SheetTitle className="text-base leading-6">Discussion</SheetTitle>
-                <SheetDescription>{chatTicket.subject}</SheetDescription>
-              </SheetHeader>
-              <div className="px-5 py-4">
-                <TicketChatPanel
-                  activities={activitiesByTicket[chatTicket.id] ?? []}
-                  currentUserId={user?.id}
-                  draft={commentDrafts[chatTicket.id] ?? ''}
-                  saving={savingCommentId === chatTicket.id}
-                  onDraftChange={(value) => setCommentDrafts((current) => ({ ...current, [chatTicket.id]: value }))}
-                  onSend={() => void handleAddComment(chatTicket.id)}
-                  onAttachFiles={(files) => void handleChatFilesSelected(chatTicket.id, files)}
-                />
-              </div>
-            </>
-          )}
-        </SheetContent>
-      </Sheet>
-
-      <Dialog open={!!closeTargetId} onOpenChange={(open) => {
-        if (!open) {
-          setCloseTargetId(null);
-          setCloseConfirmed(false);
-          setSatisfactionRating('5');
-          setClosureFeedback('');
-        }
-      }}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Close request</DialogTitle>
-            <DialogDescription>Confirm the outcome and share feedback before this request moves to Completed Requests.</DialogDescription>
-          </DialogHeader>
-          <div className="space-y-3">
-            <label htmlFor="request-close-confirmed" className="flex items-start gap-2 rounded-md border border-border px-3 py-2 text-sm">
-              <Checkbox id="request-close-confirmed" checked={closeConfirmed} onCheckedChange={(checked) => setCloseConfirmed(Boolean(checked))} />
-              <span>The issue was resolved and this request can be closed.</span>
-            </label>
-            <div className="space-y-1.5">
-              <Label>Satisfaction rating</Label>
-              <Select value={satisfactionRating} onValueChange={setSatisfactionRating}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="5">5 - Very satisfied</SelectItem>
-                  <SelectItem value="4">4 - Satisfied</SelectItem>
-                  <SelectItem value="3">3 - Neutral</SelectItem>
-                  <SelectItem value="2">2 - Unsatisfied</SelectItem>
-                  <SelectItem value="1">1 - Very unsatisfied</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <Textarea
-              value={closureFeedback}
-              onChange={(event) => setClosureFeedback(event.target.value)}
-              rows={3}
-              placeholder="Optional feedback"
-            />
-          </div>
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setCloseTargetId(null)}>Cancel</Button>
-            <Button onClick={() => void handleCloseTicket()} disabled={!closeConfirmed || (!!closeTargetId && savingCommentId === closeTargetId)}>
-              {!!closeTargetId && savingCommentId === closeTargetId ? 'Closing...' : 'Close request'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/src/pages/tickets/NewTicket.tsx
+++ b/src/pages/tickets/NewTicket.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { STALE } from '@/lib/queryClient';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, ListTodo } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { PageHeader } from '@/components/shared/PageHeader';
+import { Button } from '@/components/ui/button';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -28,6 +29,7 @@ import {
   type DuplicateTicketCandidate,
 } from '@/services/ticketService';
 import { getRequestModuleSettings } from '@/services/requestModuleSettingsService';
+import { canManagePortalQueue } from '@/lib/portalAccess';
 import { uploadTicketAttachment } from '@flc/platform-services';
 import { getInternalRequestApprovalPlan } from '@flc/internal-requests';
 import type { AppRole } from '@/types';
@@ -76,6 +78,7 @@ export default function NewTicket() {
   const autoFilledDescriptionRef = useRef('');
 
   const roleContext = ROLE_CONTEXT[user?.role as AppRole] ?? DEFAULT_ROLE_CONTEXT;
+  const canManageQueue = canManagePortalQueue(user);
 
   const form = useForm<TicketFormData>({
     resolver: zodResolver(ticketSchema),
@@ -563,6 +566,14 @@ export default function NewTicket() {
             { label: 'Internal Requests', path: '/portal' },
             { label: 'New request' },
           ]}
+          actions={canManageQueue ? (
+            <Button asChild variant="outline" size="sm" className="gap-1.5">
+              <Link to="/portal/queue">
+                <ListTodo className="h-4 w-4" />
+                Open queue
+              </Link>
+            </Button>
+          ) : undefined}
         />
       </div>
 

--- a/src/pages/tickets/PortalLanding.tsx
+++ b/src/pages/tickets/PortalLanding.tsx
@@ -2,8 +2,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import {
   Archive,
+  BarChart3,
   CheckCircle2,
   ClipboardList,
+  FileSpreadsheet,
   FolderOpen,
   Inbox,
   Megaphone,
@@ -194,6 +196,12 @@ export default function PortalLanding() {
           {canManageQueue && (
             <>
               <QuickLinkCard
+                to="/portal/dashboard"
+                icon={BarChart3}
+                title="Manager Dashboard"
+                description="Review SLA, workload, and bottleneck signals"
+              />
+              <QuickLinkCard
                 to="/portal/queue"
                 icon={ClipboardList}
                 title="Pending / Active Requests"
@@ -204,6 +212,12 @@ export default function PortalLanding() {
                 icon={Archive}
                 title="Completed Requests"
                 description="Browse requester-confirmed closed requests"
+              />
+              <QuickLinkCard
+                to="/portal/reports"
+                icon={FileSpreadsheet}
+                title="Reports"
+                description="Analyze SLA, owner, category, and aging trends"
               />
             </>
           )}

--- a/src/pages/tickets/RequestHistory.tsx
+++ b/src/pages/tickets/RequestHistory.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { STALE } from '@/lib/queryClient';
-import { toast } from 'sonner';
 import {
   Archive,
   ChevronLeft,
@@ -22,32 +22,15 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { PageHeader } from '@/components/shared/PageHeader';
-import { RequestDetailPanel } from '@/components/tickets/RequestDetailPanel';
-import {
-  Drawer,
-  DrawerContent,
-} from '@/components/ui/drawer';
 import { useRequestCategories } from '@/hooks/useRequestCategories';
-import { useRequestFormFields } from '@/hooks/useRequestFormFields';
-import { useRequestSubcategories } from '@/hooks/useRequestSubcategories';
 import { useTicketsRealtime } from '@/hooks/useTicketsRealtime';
-import { usePersistedDraftMap } from '@/hooks/usePersistedDraftMap';
 import {
   listCompanyTicketsPage,
-  listTicketActivity,
-  type CompanyTicketRecord,
-  type TicketActivityRecord,
-  type TicketPriority,
-  type TicketStatus,
   type TicketStatusFilter,
-  updateTicket,
-  addTicketComment,
 } from '@/services/ticketService';
-import { listAttachmentsForTickets, type TicketAttachmentRecord } from '@flc/platform-services';
-import { listProfiles } from '@flc/auth';
 import { getRequestCategoryLabel } from '@/lib/requestCategories';
 import { formatTicketLabel, priorityColorMap, statusColorMap } from '@/lib/requestFormatters';
-import { getRequestAssignees } from '@/lib/requestAssignees';
+import { openTicketWorkspace } from '@/lib/ticketWorkspaceNavigation';
 import { formatDistanceToNow } from 'date-fns';
 
 type HistoryStatusFilter = 'closed';
@@ -58,58 +41,16 @@ const historyStatusOptions: Array<{ value: HistoryStatusFilter; label: string }>
   { value: 'closed', label: 'Closed' },
 ];
 
-const priorityOptions: Array<{ value: TicketPriority; label: string }> = [
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-];
-
-const statusOptions: Array<{ value: TicketStatus; label: string }> = [
-  { value: 'open', label: 'Open' },
-  { value: 'in_progress', label: 'In Progress' },
-  { value: 'pending_requester', label: 'Pending Requester' },
-  { value: 'pending_owner_review', label: 'Pending Owner Review' },
-  { value: 'completed_by_owner', label: 'Completed by Owner' },
-  { value: 'closed', label: 'Closed' },
-  { value: 'reopened', label: 'Reopened' },
-  { value: 'cancelled', label: 'Cancelled' },
-];
-
-function useIsLargeScreen() {
-  const [isLargeScreen, setIsLargeScreen] = useState(() => {
-    if (typeof window === 'undefined') return true;
-    return window.matchMedia('(min-width: 1024px)').matches;
-  });
-  useEffect(() => {
-    if (typeof window === 'undefined') return undefined;
-    const mq = window.matchMedia('(min-width: 1024px)');
-    const onChange = () => setIsLargeScreen(mq.matches);
-    onChange();
-    mq.addEventListener('change', onChange);
-    return () => mq.removeEventListener('change', onChange);
-  }, []);
-  return isLargeScreen;
-}
-
 export default function RequestHistory() {
   const { user } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
-  const isLargeScreen = useIsLargeScreen();
   const { categories } = useRequestCategories(user?.company_id, true);
-  const { subcategories } = useRequestSubcategories(user?.company_id, { includeInactive: true });
-  const { fields: formFields } = useRequestFormFields(user?.company_id, { includeInactive: true });
 
-  const [statusFilter, setStatusFilter] = useState<HistoryStatusFilter>('archived');
+  const [statusFilter, setStatusFilter] = useState<HistoryStatusFilter>('closed');
   const [searchTerm, setSearchTerm] = useState('');
   const [page, setPage] = useState(1);
-  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
-  const [detailDrawerOpen, setDetailDrawerOpen] = useState(false);
-  const [savingTicketId, setSavingTicketId] = useState<string | null>(null);
-
-  const customFieldLabelMap = useMemo(
-    () => Object.fromEntries(formFields.map((f) => [`${f.category_key}:${f.key}`, f.label])),
-    [formFields],
-  );
 
   // Reset page when filters change
   useEffect(() => {
@@ -122,24 +63,12 @@ export default function RequestHistory() {
     queryKey: historyKey,
     queryFn: async () => {
       const statusParam: TicketStatusFilter = 'closed';
-      const [{ data, error: fetchError }, profileResult] = await Promise.all([
-        listCompanyTicketsPage(user!.company_id, { page, pageSize: HISTORY_PAGE_SIZE, status: statusParam, search: searchTerm }),
-        listProfiles(user!.company_id),
-      ]);
+      const { data, error: fetchError } = await listCompanyTicketsPage(user!.company_id, { page, pageSize: HISTORY_PAGE_SIZE, status: statusParam, search: searchTerm });
       if (fetchError) throw new Error(fetchError.message || 'Unable to load request history.');
-      if (profileResult.error) throw new Error(profileResult.error || 'Unable to load profiles.');
       const nextTickets = data?.rows ?? [];
-      const ticketIds = nextTickets.map((t) => t.id);
-      const [{ data: activityData }, { data: attachmentData }] = await Promise.all([
-        listTicketActivity(ticketIds, user!.company_id),
-        listAttachmentsForTickets(ticketIds, user!.company_id),
-      ]);
       return {
         tickets: nextTickets,
         totalCount: data?.totalCount ?? 0,
-        assignees: getRequestAssignees(profileResult.data),
-        activitiesByTicket: activityData ?? {} as Record<string, TicketActivityRecord[]>,
-        attachmentsByTicket: attachmentData ?? {} as Record<string, TicketAttachmentRecord[]>,
       };
     },
     enabled: !!user,
@@ -149,24 +78,6 @@ export default function RequestHistory() {
   const error = queryError ? (queryError as Error).message : null;
   const tickets = useMemo(() => historyData?.tickets ?? [], [historyData]);
   const totalCount = historyData?.totalCount ?? 0;
-  const assignees = useMemo(() => historyData?.assignees ?? [], [historyData]);
-  const activitiesByTicket = useMemo(() => historyData?.activitiesByTicket ?? {}, [historyData]);
-  const attachmentsByTicket = useMemo(() => historyData?.attachmentsByTicket ?? {}, [historyData]);
-
-  // Drafts overlay the server state — present in the map only when the user
-  // has actually typed something. The textarea read pattern below falls back
-  // to the ticket's resolution_note when no draft exists, so we no longer
-  // need a seed effect that pre-populated every ticket id.
-  const [noteDrafts, setNoteDrafts, clearNoteDraft] = usePersistedDraftMap(
-    'history:note',
-    user?.company_id,
-    user?.id,
-  );
-  const [commentDrafts, setCommentDrafts, clearCommentDraft] = usePersistedDraftMap(
-    'history:comment',
-    user?.company_id,
-    user?.id,
-  );
 
   const loadTickets = () => void queryClient.invalidateQueries({ queryKey: historyKey });
 
@@ -184,86 +95,14 @@ export default function RequestHistory() {
     onChange: invalidateHistory,
   });
 
-  const selectedTicket = useMemo(
-    () => tickets.find((t) => t.id === selectedTicketId) ?? null,
-    [tickets, selectedTicketId],
-  );
-
   function handleSelectTicket(ticketId: string) {
-    setSelectedTicketId(ticketId);
-    if (!isLargeScreen) setDetailDrawerOpen(true);
+    openTicketWorkspace(navigate, ticketId, {
+      source: 'history',
+      path: `${location.pathname}${location.search}`,
+      page,
+      filters: { statusFilter, searchTerm },
+    });
   }
-
-  async function handleUpdateTicket(ticketId: string, updates: Parameters<typeof updateTicket>[1]) {
-    if (!user) return;
-    setSavingTicketId(ticketId);
-    const result = await updateTicket(ticketId, updates, { userId: user.id, companyId: user.company_id });
-    if (result.error) {
-      toast.error('Failed to update request', { description: result.error.message });
-    } else {
-      await loadTickets();
-      toast.success('Request updated');
-    }
-    setSavingTicketId(null);
-  }
-
-  async function handleAddComment(ticketId: string) {
-    if (!user) return;
-    const message = commentDrafts[ticketId]?.trim();
-    if (!message) return;
-
-    setSavingTicketId(ticketId);
-    const result = await addTicketComment(ticketId, { message }, { userId: user.id, companyId: user.company_id });
-    if (result.error) {
-      toast.error('Failed to add comment', { description: result.error.message });
-    } else {
-      clearCommentDraft(ticketId);
-      // Activity is owned by the historyKey query — invalidate to refetch the
-      // ticket's updated activity timeline alongside everything else.
-      await queryClient.invalidateQueries({ queryKey: historyKey });
-    }
-    setSavingTicketId(null);
-  }
-
-  const renderDetailPanel = (ticket: CompanyTicketRecord, variant: 'pane' | 'drawer' = 'pane') => (
-    <RequestDetailPanel
-      ticket={ticket}
-      categories={categories}
-      subcategories={subcategories}
-      assignees={assignees}
-      activities={activitiesByTicket[ticket.id] ?? []}
-      attachments={attachmentsByTicket[ticket.id] ?? []}
-      customFieldLabelMap={customFieldLabelMap}
-      statusOptions={statusOptions}
-      priorityOptions={priorityOptions}
-      currentUserId={user?.id}
-      saving={savingTicketId === ticket.id}
-      // Drafts overlay the server state: an entry in noteDrafts means the
-      // user has typed something; otherwise we show the ticket's current
-      // resolution_note. After a successful save the draft is cleared and
-      // the textarea naturally falls back to the new server value.
-      noteDraft={noteDrafts[ticket.id] ?? ticket.resolution_note ?? ''}
-      commentDraft={commentDrafts[ticket.id] ?? ''}
-      canReviewApproval={false}
-      canManageWorkflow={false}
-      canCloseAsRequester={false}
-      variant={variant}
-      onStatusChange={() => undefined}
-      onPriorityChange={(ticketId, priority) => void handleUpdateTicket(ticketId, { priority })}
-      onAssignmentChange={(ticketId, value) =>
-        void handleUpdateTicket(ticketId, { assigned_to: value === 'unassigned' ? null : value })
-      }
-      onResolutionNoteChange={(ticketId, value) => setNoteDrafts((prev) => ({ ...prev, [ticketId]: value }))}
-      onResolutionNoteSave={async (ticketId) => {
-        const nextNote = noteDrafts[ticketId] ?? ticket.resolution_note ?? '';
-        await handleUpdateTicket(ticketId, { resolution_note: nextNote });
-        clearNoteDraft(ticketId);
-      }}
-      onCommentChange={(ticketId, value) => setCommentDrafts((prev) => ({ ...prev, [ticketId]: value }))}
-      onAddComment={(ticketId) => void handleAddComment(ticketId)}
-      onReviewApproval={() => undefined}
-    />
-  );
 
   const totalPages = Math.ceil(totalCount / HISTORY_PAGE_SIZE);
 
@@ -323,7 +162,7 @@ export default function RequestHistory() {
       {/* Content */}
       <div className="flex flex-1 gap-4 overflow-hidden">
         {/* Left: ticket list */}
-        <div className={`flex flex-col gap-2 overflow-y-auto ${isLargeScreen && selectedTicketId ? 'w-[420px] flex-shrink-0' : 'flex-1'}`}>
+        <div className="flex flex-1 flex-col gap-2 overflow-y-auto">
           {loading ? (
             <div className="flex items-center justify-center gap-3 py-16 text-muted-foreground">
               <Loader2 className="h-5 w-5 animate-spin" />
@@ -343,13 +182,12 @@ export default function RequestHistory() {
             <>
               {tickets.map((ticket) => {
                 const categoryLabel = getRequestCategoryLabel(ticket.category, categories);
-                const isSelected = ticket.id === selectedTicketId;
                 return (
                   <button
                     key={ticket.id}
                     type="button"
                     onClick={() => handleSelectTicket(ticket.id)}
-                    className={`w-full rounded-lg border bg-card p-3.5 text-left shadow-sm transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${isSelected ? 'border-primary/50 bg-accent/60 ring-1 ring-primary/30' : ''}`}
+                    className="w-full rounded-lg border bg-card p-3.5 text-left shadow-sm transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0 flex-1">
@@ -407,25 +245,7 @@ export default function RequestHistory() {
             </>
           )}
         </div>
-
-        {/* Right: detail panel (large screens) */}
-        {isLargeScreen && selectedTicket && (
-          <div className="flex-1 overflow-y-auto rounded-lg border bg-card shadow-sm">
-            {renderDetailPanel(selectedTicket)}
-          </div>
-        )}
       </div>
-
-      {/* Mobile drawer */}
-      {!isLargeScreen && selectedTicket && (
-        <Drawer open={detailDrawerOpen} onOpenChange={setDetailDrawerOpen}>
-          <DrawerContent className="max-h-[90vh]">
-            <div className="overflow-y-auto p-4">
-              {renderDetailPanel(selectedTicket, 'drawer')}
-            </div>
-          </DrawerContent>
-        </Drawer>
-      )}
     </div>
   );
 }

--- a/src/pages/tickets/RequestQueue.tsx
+++ b/src/pages/tickets/RequestQueue.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
@@ -25,12 +26,10 @@ import { useAuth } from '@/contexts/AuthContext';
 import { STALE } from '@/lib/queryClient';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { PanelErrorBoundary } from '@/components/shared/PanelErrorBoundary';
 import { PageHeader } from '@/components/shared/PageHeader';
 import { HrmsEmptyState } from '@/components/shared/HrmsEmptyState';
 import { StandardTable, type StandardTableColumn } from '@/components/shared/StandardTable';
 import { TableSkeleton } from '@/components/ui/TableSkeleton';
-import { RequestDetailPanel } from '@/components/tickets/RequestDetailPanel';
 import { RequestStatusBadge } from '@/components/tickets/RequestBadge';
 import { TicketApprovalSummary } from '@/components/tickets/TicketApprovalSummary';
 import { TicketOperationalBadges } from '@/components/tickets/TicketOperationalIndicators';
@@ -52,17 +51,8 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useRequestCategories } from '@/hooks/useRequestCategories';
-import { useRequestFormFields } from '@/hooks/useRequestFormFields';
 import { useRequestSubcategories } from '@/hooks/useRequestSubcategories';
 import { useTicketsRealtime } from '@/hooks/useTicketsRealtime';
-import { usePersistedDraftMap } from '@/hooks/usePersistedDraftMap';
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet';
 import {
   Dialog,
   DialogContent,
@@ -71,27 +61,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
-import { TicketChatPanel } from '@/components/tickets/TicketChatPanel';
 import {
-  addTicketInternalNote,
-  addTicketComment,
-  closeTicketByRequester,
   getCompanyTicketStatusCounts,
   listTicketChatSummaries,
-  listTicketInternalNotes,
   listCompanyTicketsPage,
   listTicketActivity,
-  markTicketChatRead,
-  markTicketCompletedByOwner,
-  requestTicketMoreInformation,
   type CompanyTicketRecord,
   type PaginatedTicketResult,
   type TicketActivityRecord,
   type TicketChatSummary,
-  type TicketCompletionCategory,
-  type TicketInternalNoteRecord,
   type TicketPriority,
   type TicketResponsibleParty,
   type TicketStatus,
@@ -109,9 +87,6 @@ import {
   type RequestOperationalIndicator,
   type RequestSavedFilterRecord,
 } from '@/services/requestManagementService';
-import { uploadTicketAttachment } from '@flc/platform-services';
-import { reviewInternalRequestApproval } from '@flc/internal-requests';
-import { listAttachmentsForTickets, type TicketAttachmentRecord } from '@flc/platform-services';
 import { listProfiles } from '@flc/auth';
 import { getRequestCategoryLabel } from '@/lib/requestCategories';
 import { getRequestSubcategoryLabel } from '@/lib/requestSubcategories';
@@ -120,11 +95,9 @@ import { formatSlaState, getTicketSlaSummary } from '@/lib/ticketSla';
 import {
   downloadCsv,
   formatTicketLabel,
-  isApprovalAssignedToUser,
   isOpenStatus,
 } from '@/lib/requestFormatters';
-
-type ApprovalReviewTarget = { ticketId: string; decision: 'approved' | 'rejected' } | null;
+import { openTicketWorkspace, type TicketWorkspaceReturnState } from '@/lib/ticketWorkspaceNavigation';
 
 const statusOptions: Array<{ value: TicketStatus; label: string }> = [
   { value: 'open', label: 'Open' },
@@ -145,19 +118,18 @@ const priorityOptions: Array<{ value: TicketPriority; label: string }> = [
 
 const REQUEST_QUEUE_PAGE_SIZE = 25;
 
-// formatTicketLabel, isOpenStatus, isApprovalAssignedToUser, csvCell, downloadCsv
-// are now imported from '@/lib/requestFormatters'
+// formatTicketLabel, isOpenStatus, csvCell, downloadCsv are imported from '@/lib/requestFormatters'
 
 export default function RequestQueue() {
   const { user } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
+  const contentScrollRef = useRef<HTMLDivElement | null>(null);
   const { categories } = useRequestCategories(user?.company_id, true);
   const { subcategories } = useRequestSubcategories(user?.company_id, { includeInactive: true });
-  const { fields: formFields } = useRequestFormFields(user?.company_id, { includeInactive: true });
   const [activitiesByTicket, setActivitiesByTicket] = useState<Record<string, TicketActivityRecord[]>>({});
-  const [attachmentsByTicket, setAttachmentsByTicket] = useState<Record<string, TicketAttachmentRecord[]>>({});
   const [chatSummariesByTicket, setChatSummariesByTicket] = useState<Record<string, TicketChatSummary>>({});
-  const [internalNotesByTicket, setInternalNotesByTicket] = useState<Record<string, TicketInternalNoteRecord[]>>({});
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('active');
   const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>('all');
   const [slaFilter, setSlaFilter] = useState<SlaFilter>('all');
@@ -174,20 +146,12 @@ export default function RequestQueue() {
   const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [page, setPage] = useState(1);
-  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkSaving, setBulkSaving] = useState(false);
   const [metricsExpanded, setMetricsExpanded] = useState(() => {
     if (typeof window === 'undefined') return true;
     return window.localStorage.getItem('requestQueue.metricsExpanded') !== 'false';
   });
-  const [savingTicketId, setSavingTicketId] = useState<string | null>(null);
-  const [reviewTarget, setReviewTarget] = useState<ApprovalReviewTarget>(null);
-  const [reviewNote, setReviewNote] = useState('');
-  const [completionTargetId, setCompletionTargetId] = useState<string | null>(null);
-  const [completionCategory, setCompletionCategory] = useState<TicketCompletionCategory>('resolved');
-  const [completionChecklistConfirmed, setCompletionChecklistConfirmed] = useState(false);
-  const [chatTicketId, setChatTicketId] = useState<string | null>(null);
   const [savedFilterName, setSavedFilterName] = useState('');
   const [bulkPriorityDialogOpen, setBulkPriorityDialogOpen] = useState(false);
   const [bulkPriority, setBulkPriority] = useState<TicketPriority>('medium');
@@ -196,32 +160,6 @@ export default function RequestQueue() {
   const [bulkNotifyAudience, setBulkNotifyAudience] = useState<'requesters' | 'owners'>('requesters');
   const [bulkNotifyMessage, setBulkNotifyMessage] = useState('');
   const [bulkArchiveDialogOpen, setBulkArchiveDialogOpen] = useState(false);
-  // Drafts overlay the server state — see usePersistedDraftMap. Cycle 3.5's
-  // realtime invalidations made it routine for the ticket page to refetch
-  // while a queue manager was mid-comment; without persistence those drafts
-  // were silently destroyed every time a colleague mutated any ticket.
-  const [noteDrafts, setNoteDrafts, clearNoteDraft] = usePersistedDraftMap(
-    'queue:note',
-    user?.company_id,
-    user?.id,
-  );
-  const [commentDrafts, setCommentDrafts, clearCommentDraft] = usePersistedDraftMap(
-    'queue:comment',
-    user?.company_id,
-    user?.id,
-  );
-  const [internalNoteDrafts, setInternalNoteDrafts, clearInternalNoteDraft] = usePersistedDraftMap(
-    'queue:internal-note',
-    user?.company_id,
-    user?.id,
-  );
-  const [queueError, setQueueError] = useState<string | null>(null);
-
-  const customFieldLabelMap = useMemo(
-    () => Object.fromEntries(formFields.map((field) => [`${field.category_key}:${field.key}`, field.label])),
-    [formFields],
-  );
-
   // ─── Saved view presets ────────────────────────────────────────────────────
   type SavedViewDef = {
     id: string;
@@ -383,7 +321,7 @@ export default function RequestQueue() {
   const tickets = useMemo(() => ticketPage?.rows ?? [], [ticketPage]);
   const totalCount = ticketPage?.totalCount ?? 0;
   const loading = ticketsLoading && !ticketPage; // only hard-loading on the very first fetch
-  const error = queueError ?? (ticketQueryError ? (ticketQueryError as Error).message : null);
+  const error = ticketQueryError ? (ticketQueryError as Error).message : null;
 
   const assignees = useMemo(
     () => getRequestAssignees(profileRows ?? []),
@@ -426,21 +364,15 @@ export default function RequestQueue() {
     const ticketIds = nextTickets.map((ticket) => ticket.id);
     if (ticketIds.length === 0) {
       setActivitiesByTicket({});
-      setAttachmentsByTicket({});
       setChatSummariesByTicket({});
-      setInternalNotesByTicket({});
       return;
     }
     void Promise.all([
       listTicketActivity(ticketIds, user.company_id),
-      listAttachmentsForTickets(ticketIds, user.company_id),
       listTicketChatSummaries(ticketIds, user.id, user.company_id),
-      listTicketInternalNotes(ticketIds, user.company_id),
-    ]).then(([{ data: activityData }, { data: attachmentData }, { data: chatSummaryData }, { data: internalNoteData }]) => {
+    ]).then(([{ data: activityData }, { data: chatSummaryData }]) => {
       setActivitiesByTicket(activityData ?? {});
-      setAttachmentsByTicket(attachmentData ?? {});
       setChatSummariesByTicket(chatSummaryData ?? {});
-      setInternalNotesByTicket(internalNoteData ?? {});
     });
   }, [ticketPage, user]);
 
@@ -503,15 +435,6 @@ export default function RequestQueue() {
     [activitiesByTicket, chatSummariesByTicket, filteredTickets],
   );
 
-  const selectedTicket = useMemo(
-    () => filteredTickets.find((ticket) => ticket.id === selectedTicketId) ?? null,
-    [filteredTickets, selectedTicketId],
-  );
-  const chatTicket = useMemo(
-    () => filteredTickets.find((ticket) => ticket.id === chatTicketId) ?? null,
-    [chatTicketId, filteredTickets],
-  );
-
   const queueMetrics = useMemo(() => ({
     unassigned: tickets.filter((ticket) => isOpenStatus(ticket.status) && !ticket.assigned_to).length,
     slaBreached: tickets.filter((ticket) => getTicketSlaSummary(ticket).overall === 'breached').length,
@@ -544,70 +467,6 @@ export default function RequestQueue() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [queryClient, ...ticketQueryKey],
   );
-
-  const handleStatusChange = async (_ticketId: string, _status: TicketStatus) => {
-    setQueueError('Manual status updates are restricted. Use the workflow actions in the request detail panel.');
-  };
-
-  const handleAssignmentChange = async (ticketId: string, value: string) => {
-    if (!user) return;
-
-    const assignedTo = value === 'unassigned' ? null : value;
-    const assignee = assignees.find((profile) => profile.id === assignedTo) ?? null;
-
-    setSavingTicketId(ticketId);
-    setQueueError(null);
-
-    const { data, error: updateError } = await updateTicket(
-      ticketId,
-      { assigned_to: assignedTo },
-      { userId: user.id, companyId: user.company_id },
-    );
-
-    if (updateError || !data) {
-      setQueueError(updateError?.message || 'Unable to update request owner.');
-      setSavingTicketId(null);
-      return;
-    }
-
-    applyOptimisticTicketUpdate(ticketId, {
-      assigned_to: data.assigned_to,
-      assigned_at: data.assigned_at,
-      resolved_at: data.resolved_at,
-      resolution_note: data.resolution_note,
-      updated_at: data.updated_at,
-      assigned_to_name: assignee?.name ?? null,
-      assigned_to_email: assignee?.email ?? null,
-    });
-    setSavingTicketId(null);
-    void refreshTicketActivity(ticketId);
-  };
-
-  const handlePriorityChange = async (ticketId: string, priority: TicketPriority) => {
-    if (!user) return;
-
-    setSavingTicketId(ticketId);
-    setQueueError(null);
-
-    const { data, error: updateError } = await updateTicket(
-      ticketId,
-      { priority },
-      { userId: user.id, companyId: user.company_id },
-    );
-
-    if (updateError || !data) {
-      setQueueError(updateError?.message || 'Unable to update request priority.');
-      setSavingTicketId(null);
-      return;
-    }
-
-    applyOptimisticTicketUpdate(ticketId, {
-      priority: data.priority,
-      updated_at: data.updated_at,
-    });
-    setSavingTicketId(null);
-    void refreshTicketActivity(ticketId);
-  };
 
   const handleTicketOpen = async (ticketId: string) => {
     if (!user) return;
@@ -648,251 +507,15 @@ export default function RequestQueue() {
     void refreshTicketActivity(ticketId);
   };
 
-  const handleResolutionNoteSave = async (ticketId: string) => {
-    if (!user) return;
-    // Resolve the saveable note: prefer the user's in-progress draft;
-    // if no draft, fall back to whatever resolution_note is already on
-    // the ticket (this matches what the textarea is currently showing).
-    const ticket = tickets.find((t) => t.id === ticketId);
-    const nextNote = noteDrafts[ticketId] ?? ticket?.resolution_note ?? '';
-
-    setSavingTicketId(ticketId);
-    setQueueError(null);
-
-    const { data, error: updateError } = await updateTicket(
-      ticketId,
-      { resolution_note: nextNote },
-      { userId: user.id, companyId: user.company_id },
-    );
-
-    if (updateError || !data) {
-      setQueueError(updateError?.message || 'Unable to save the resolution note.');
-      setSavingTicketId(null);
-      return;
-    }
-
-    applyOptimisticTicketUpdate(ticketId, {
-      resolution_note: data.resolution_note,
-      resolved_at: data.resolved_at,
-      updated_at: data.updated_at,
-    });
-    // Drop the draft; the textarea now reads from the optimistically-updated
-    // server state via `noteDrafts[id] ?? ticket.resolution_note`.
-    clearNoteDraft(ticketId);
-    setSavingTicketId(null);
-    void refreshTicketActivity(ticketId);
-  };
-
-  const handleAddComment = async (ticketId: string) => {
-    if (!user) return;
-    const message = commentDrafts[ticketId]?.trim() ?? '';
-    if (!message) return;
-
-    setSavingTicketId(ticketId);
-    setQueueError(null);
-
-    const { error: commentError } = await addTicketComment(
-      ticketId,
-      { message },
-      { userId: user.id, companyId: user.company_id },
-    );
-
-    if (commentError) {
-      setQueueError(commentError.message || 'Unable to add comment.');
-      setSavingTicketId(null);
-      return;
-    }
-
-    clearCommentDraft(ticketId);
-    setSavingTicketId(null);
-    void refreshTicketActivity(ticketId);
-  };
-
-  const handleAddInternalNote = async (ticketId: string) => {
-    if (!user) return;
-    const note = internalNoteDrafts[ticketId]?.trim() ?? '';
-    if (!note) return;
-
-    setSavingTicketId(ticketId);
-    setQueueError(null);
-    const { error: noteError } = await addTicketInternalNote(
-      ticketId,
-      { note },
-      { userId: user.id, companyId: user.company_id },
-    );
-    if (noteError) {
-      setQueueError(noteError.message || 'Unable to add internal note.');
-      setSavingTicketId(null);
-      return;
-    }
-    clearInternalNoteDraft(ticketId);
-    setSavingTicketId(null);
-    const [{ data: notes }, { data: activity }] = await Promise.all([
-      listTicketInternalNotes([ticketId], user.company_id),
-      listTicketActivity([ticketId], user.company_id),
-    ]);
-    if (notes) setInternalNotesByTicket((current) => ({ ...current, ...notes }));
-    if (activity) setActivitiesByTicket((current) => ({ ...current, ...activity }));
-  };
-
-  const handleOpenChat = async (ticketId: string) => {
-    if (!user) return;
-    setChatTicketId(ticketId);
-    await markTicketChatRead(ticketId, { userId: user.id, companyId: user.company_id });
-    setChatSummariesByTicket((current) => ({
-      ...current,
-      [ticketId]: {
-        ticket_id: ticketId,
-        message_count: current[ticketId]?.message_count ?? 0,
-        unread_count: 0,
-        latest_message_at: current[ticketId]?.latest_message_at ?? null,
-      },
-    }));
-  };
-
-  const handleRequestMoreInformation = async (ticketId: string) => {
-    if (!user) return;
-    const message = commentDrafts[ticketId]?.trim() ?? '';
-    if (!message) {
-      setQueueError('Add a chat message before requesting more information.');
-      return;
-    }
-    setSavingTicketId(ticketId);
-    setQueueError(null);
-    const { data, error: workflowError } = await requestTicketMoreInformation(
-      ticketId,
-      { message },
-      { userId: user.id, companyId: user.company_id },
-    );
-    if (workflowError || !data) {
-      setQueueError(workflowError?.message || 'Unable to request more information.');
-      setSavingTicketId(null);
-      return;
-    }
-    clearCommentDraft(ticketId);
-    applyOptimisticTicketUpdate(ticketId, {
-      status: data.status,
-      current_responsible_party: data.current_responsible_party,
-      next_action: data.next_action,
-      updated_at: data.updated_at,
-      status_changed_at: data.status_changed_at,
-    });
-    setSavingTicketId(null);
-    void refreshTicketActivity(ticketId);
-  };
-
-  const handleMarkCompleted = async (ticketId: string) => {
-    setCompletionTargetId(ticketId);
-    setCompletionCategory('resolved');
-    setCompletionChecklistConfirmed(false);
-  };
-
-  const submitCompletion = async () => {
-    if (!user) return;
-    const ticketId = completionTargetId;
-    if (!ticketId) return;
-    const ticket = tickets.find((row) => row.id === ticketId);
-    const resolutionNote = noteDrafts[ticketId] ?? ticket?.resolution_note ?? '';
-    setSavingTicketId(ticketId);
-    setQueueError(null);
-    const { data, error: workflowError } = await markTicketCompletedByOwner(
-      ticketId,
-      {
-        resolutionNote,
-        completionCategory,
-        checklistConfirmed: completionChecklistConfirmed,
-        slaBreachReason: ticket?.sla_breach_reason ?? null,
-      },
-      { userId: user.id, companyId: user.company_id },
-    );
-    if (workflowError || !data) {
-      setQueueError(workflowError?.message || 'Unable to mark request completed.');
-      setSavingTicketId(null);
-      return;
-    }
-    clearNoteDraft(ticketId);
-    applyOptimisticTicketUpdate(ticketId, {
-      status: data.status,
-      resolution_note: data.resolution_note,
-      current_responsible_party: data.current_responsible_party,
-      next_action: data.next_action,
-      updated_at: data.updated_at,
-      status_changed_at: data.status_changed_at,
-    });
-    setSavingTicketId(null);
-    setCompletionTargetId(null);
-    setCompletionChecklistConfirmed(false);
-    void refreshTicketActivity(ticketId);
-  };
-
-  const handleCloseRequest = async (ticketId: string) => {
-    if (!user) return;
-    setSavingTicketId(ticketId);
-    setQueueError(null);
-    const { data, error: workflowError } = await closeTicketByRequester(
-      ticketId,
-      { confirmedResolved: true, satisfactionRating: 5 },
-      { userId: user.id, companyId: user.company_id },
-    );
-    if (workflowError || !data) {
-      setQueueError(workflowError?.message || 'Unable to close request.');
-      setSavingTicketId(null);
-      return;
-    }
-    applyOptimisticTicketUpdate(ticketId, {
-      status: data.status,
-      current_responsible_party: data.current_responsible_party,
-      next_action: data.next_action,
-      updated_at: data.updated_at,
-      status_changed_at: data.status_changed_at,
-      resolved_at: data.resolved_at,
-    });
-    setSavingTicketId(null);
-    void refreshTicketActivity(ticketId);
-  };
-
-  const handleChatFilesSelected = async (ticketId: string, files: File[]) => {
-    if (!user || files.length === 0) return;
-    setSavingTicketId(ticketId);
-    setQueueError(null);
-    const results = await Promise.all(files.map((file) => uploadTicketAttachment(file, ticketId, user.company_id, user.id)));
-    const failed = results.filter((result) => result.error);
-    const uploadedNames = files.filter((_, index) => !results[index].error).map((file) => file.name);
-    if (uploadedNames.length > 0) {
-      await addTicketComment(
-        ticketId,
-        { message: `Attached ${uploadedNames.length} file${uploadedNames.length === 1 ? '' : 's'}.`, attachmentNames: uploadedNames },
-        { userId: user.id, companyId: user.company_id },
-      );
-    }
-    if (failed.length > 0) setQueueError(`${failed.length} attachment${failed.length === 1 ? '' : 's'} failed to upload.`);
-    setSavingTicketId(null);
-    void refreshTicketActivity(ticketId);
-  };
-
-  const handleApprovalReview = async () => {
-    if (!user || !reviewTarget) return;
-
-    setSavingTicketId(reviewTarget.ticketId);
-    setQueueError(null);
-    const { error: reviewError } = await reviewInternalRequestApproval(
-      reviewTarget.ticketId,
-      reviewTarget.decision,
-      reviewNote,
-      { userId: user.id, companyId: user.company_id },
-    );
-    setSavingTicketId(null);
-
-    if (reviewError) {
-      setQueueError(reviewError);
-      return;
-    }
-
-    toast.success(reviewTarget.decision === 'approved' ? 'Request approval recorded' : 'Request rejected');
-    setReviewTarget(null);
-    setReviewNote('');
-    // Invalidate so the next render fetches fresh data from the server
-    await queryClient.invalidateQueries({ queryKey: ['ticketQueue', user.company_id] });
+  const handleOpenChat = (ticketId: string) => {
+    openTicketWorkspace(navigate, ticketId, {
+      source: 'queue',
+      path: `${location.pathname}${location.search}`,
+      page,
+      activeSavedView: activeSavedView ?? undefined,
+      filters: currentFilterPayload,
+      scrollTop: contentScrollRef.current?.scrollTop ?? 0,
+    }, 'chat');
   };
 
   const handleExportCsv = () => {
@@ -915,55 +538,6 @@ export default function RequestQueue() {
 
     downloadCsv(`internal-requests-${new Date().toISOString().slice(0, 10)}.csv`, rows);
   };
-
-  const renderDetailPanel = (ticket: CompanyTicketRecord, variant: 'pane' | 'drawer' = 'pane') => (
-    <RequestDetailPanel
-      ticket={ticket}
-      categories={categories}
-      subcategories={subcategories}
-      assignees={assignees}
-      activities={activitiesByTicket[ticket.id] ?? []}
-      internalNotes={internalNotesByTicket[ticket.id] ?? []}
-      operationalIndicator={indicatorsByTicket[ticket.id]}
-      attachments={attachmentsByTicket[ticket.id] ?? []}
-      customFieldLabelMap={customFieldLabelMap}
-      statusOptions={statusOptions}
-      priorityOptions={priorityOptions}
-      currentUserId={user?.id}
-      saving={savingTicketId === ticket.id}
-      // Drafts overlay the server state — see usePersistedDraftMap.
-      noteDraft={noteDrafts[ticket.id] ?? ticket.resolution_note ?? ''}
-      commentDraft={commentDrafts[ticket.id] ?? ''}
-      internalNoteDraft={internalNoteDrafts[ticket.id] ?? ''}
-      canReviewApproval={isApprovalAssignedToUser(ticket, user)}
-      canManageWorkflow={ticket.submitted_by !== user?.id}
-      canCloseAsRequester={ticket.submitted_by === user?.id}
-      variant={variant}
-      onStatusChange={(ticketId, status) => void handleStatusChange(ticketId, status)}
-      onPriorityChange={(ticketId, priority) => void handlePriorityChange(ticketId, priority)}
-      onAssignmentChange={(ticketId, value) => void handleAssignmentChange(ticketId, value)}
-      onResolutionNoteChange={(ticketId, value) => setNoteDrafts((current) => ({
-        ...current,
-        [ticketId]: value,
-      }))}
-      onResolutionNoteSave={(ticketId) => void handleResolutionNoteSave(ticketId)}
-      onCommentChange={(ticketId, value) => setCommentDrafts((current) => ({
-        ...current,
-        [ticketId]: value,
-      }))}
-      onAddComment={(ticketId) => void handleAddComment(ticketId)}
-      onInternalNoteChange={(ticketId, value) => setInternalNoteDrafts((current) => ({
-        ...current,
-        [ticketId]: value,
-      }))}
-      onAddInternalNote={(ticketId) => void handleAddInternalNote(ticketId)}
-      onRequestMoreInformation={(ticketId) => void handleRequestMoreInformation(ticketId)}
-      onMarkCompleted={(ticketId) => void handleMarkCompleted(ticketId)}
-      onCloseRequest={(ticketId) => void handleCloseRequest(ticketId)}
-      onChatFilesSelected={(ticketId, files) => void handleChatFilesSelected(ticketId, files)}
-      onReviewApproval={(ticketId, decision) => setReviewTarget({ ticketId, decision })}
-    />
-  );
 
   const hasActiveFilters =
     statusFilter !== 'active'
@@ -1029,6 +603,45 @@ export default function RequestQueue() {
     updatedFrom,
     updatedTo,
   ]);
+
+  useEffect(() => {
+    const state = (location.state as { ticketWorkspaceReturnState?: TicketWorkspaceReturnState } | null)?.ticketWorkspaceReturnState;
+    if (!state || state.source !== 'queue') return;
+    const filters = state.filters as Partial<typeof currentFilterPayload> | undefined;
+    if (filters) {
+      setStatusFilter((filters.statusFilter as StatusFilter) ?? 'active');
+      setPriorityFilter((filters.priorityFilter as PriorityFilter) ?? 'all');
+      setSlaFilter((filters.slaFilter as SlaFilter) ?? 'all');
+      setAssignedToFilter((filters.assignedToFilter as AssigneeFilter) ?? 'all');
+      setCategoryFilter(String(filters.categoryFilter ?? 'all'));
+      setSubcategoryFilter(String(filters.subcategoryFilter ?? 'all'));
+      setResponsiblePartyFilter((filters.responsiblePartyFilter as TicketResponsibleParty | 'all') ?? 'all');
+      setSubmittedFrom(String(filters.submittedFrom ?? ''));
+      setSubmittedTo(String(filters.submittedTo ?? ''));
+      setUpdatedFrom(String(filters.updatedFrom ?? ''));
+      setUpdatedTo(String(filters.updatedTo ?? ''));
+      setUnreadOnly(Boolean(filters.unreadOnly));
+      setReopenedOnly(Boolean(filters.reopenedOnly));
+      setSearchTerm(String(filters.searchTerm ?? ''));
+    }
+    if (state.page) setPage(state.page);
+    window.setTimeout(() => {
+      if (contentScrollRef.current && typeof state.scrollTop === 'number') {
+        contentScrollRef.current.scrollTop = state.scrollTop;
+      }
+    }, 0);
+  }, [location.state]);
+
+  const handleOpenTicketWorkspace = (ticketId: string) => {
+    openTicketWorkspace(navigate, ticketId, {
+      source: 'queue',
+      path: `${location.pathname}${location.search}`,
+      page,
+      activeSavedView: activeSavedView ?? undefined,
+      filters: currentFilterPayload,
+      scrollTop: contentScrollRef.current?.scrollTop ?? 0,
+    });
+  };
 
   const applySavedFilter = (filter: RequestSavedFilterRecord) => {
     const filters = filter.filters as Partial<typeof currentFilterPayload>;
@@ -1424,7 +1037,7 @@ export default function RequestQueue() {
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div ref={contentScrollRef} className="min-h-0 flex-1 overflow-y-auto">
         {loading ? (
           <TableSkeleton rows={8} cols={6} />
         ) : error ? (
@@ -1495,103 +1108,12 @@ export default function RequestQueue() {
               </>
             )}
             onRowClick={(ticket) => {
-              setSelectedTicketId(ticket.id);
               void handleTicketOpen(ticket.id);
+              handleOpenTicketWorkspace(ticket.id);
             }}
           />
         )}
       </div>
-
-      {/* Request detail drawer */}
-      <Sheet
-        open={!!selectedTicket}
-        onOpenChange={(open) => {
-          if (!open) setSelectedTicketId(null);
-        }}
-      >
-        <SheetContent side="right" className="w-full gap-0 overflow-y-auto p-0 sm:max-w-2xl">
-          {selectedTicket && (
-            <>
-              <SheetHeader className="sr-only">
-                <SheetTitle>{selectedTicket.subject}</SheetTitle>
-                <SheetDescription>Internal request detail</SheetDescription>
-              </SheetHeader>
-              <div className="px-4 py-4">
-                <PanelErrorBoundary scope="request-queue:detail" resetKey={selectedTicket.id}>
-                  {renderDetailPanel(selectedTicket, 'drawer')}
-                </PanelErrorBoundary>
-              </div>
-            </>
-          )}
-        </SheetContent>
-      </Sheet>
-
-      <Sheet open={!!chatTicket} onOpenChange={(open) => { if (!open) setChatTicketId(null); }}>
-        <SheetContent side="right" className="w-full gap-0 overflow-y-auto p-0 sm:max-w-md">
-          {chatTicket && (
-            <>
-              <SheetHeader className="space-y-1 border-b border-border px-5 py-4 text-left">
-                <SheetTitle className="text-base leading-6">Discussion</SheetTitle>
-                <SheetDescription>{chatTicket.subject}</SheetDescription>
-              </SheetHeader>
-              <div className="px-5 py-4">
-                <TicketChatPanel
-                  activities={activitiesByTicket[chatTicket.id] ?? []}
-                  currentUserId={user?.id}
-                  draft={commentDrafts[chatTicket.id] ?? ''}
-                  saving={savingTicketId === chatTicket.id}
-                  onDraftChange={(value) => setCommentDrafts((current) => ({ ...current, [chatTicket.id]: value }))}
-                  onSend={() => void handleAddComment(chatTicket.id)}
-                  onAttachFiles={(files) => void handleChatFilesSelected(chatTicket.id, files)}
-                />
-              </div>
-            </>
-          )}
-        </SheetContent>
-      </Sheet>
-
-      <Dialog open={!!completionTargetId} onOpenChange={(open) => {
-        if (!open) {
-          setCompletionTargetId(null);
-          setCompletionChecklistConfirmed(false);
-        }
-      }}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Mark request completed</DialogTitle>
-            <DialogDescription>Confirm the owner completion details before the requester closes the request.</DialogDescription>
-          </DialogHeader>
-          <div className="space-y-3">
-            <div className="space-y-1.5">
-              <Label>Completion category</Label>
-              <Select value={completionCategory} onValueChange={(value) => setCompletionCategory(value as TicketCompletionCategory)}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="resolved">Resolved</SelectItem>
-                  <SelectItem value="rejected">Rejected</SelectItem>
-                  <SelectItem value="duplicate">Duplicate</SelectItem>
-                  <SelectItem value="cancelled">Cancelled</SelectItem>
-                  <SelectItem value="not_applicable">Not Applicable</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <label htmlFor="request-completion-checklist" className="flex items-start gap-2 rounded-md border border-border px-3 py-2 text-sm">
-              <Checkbox
-                id="request-completion-checklist"
-                checked={completionChecklistConfirmed}
-                onCheckedChange={(checked) => setCompletionChecklistConfirmed(Boolean(checked))}
-              />
-              <span>Resolution summary, attachments, checklist items, and breach reason are complete where required.</span>
-            </label>
-          </div>
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setCompletionTargetId(null)}>Cancel</Button>
-            <Button onClick={() => void submitCompletion()} disabled={!completionChecklistConfirmed || (!!completionTargetId && savingTicketId === completionTargetId)}>
-              {!!completionTargetId && savingTicketId === completionTargetId ? 'Saving...' : 'Mark completed'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       <Dialog open={bulkPriorityDialogOpen} onOpenChange={(open) => {
         setBulkPriorityDialogOpen(open);
@@ -1663,41 +1185,6 @@ export default function RequestQueue() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={!!reviewTarget} onOpenChange={(open) => {
-        if (!open) {
-          setReviewTarget(null);
-          setReviewNote('');
-        }
-      }}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>{reviewTarget?.decision === 'approved' ? 'Approve request' : 'Reject request'}</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-2">
-            <p className="text-sm text-muted-foreground">
-              {reviewTarget?.decision === 'approved'
-                ? 'Record your approval decision for the current workflow step.'
-                : 'Rejecting this approval will cancel the request and notify the requester.'}
-            </p>
-            <Textarea
-              value={reviewNote}
-              onChange={(event) => setReviewNote(event.target.value)}
-              rows={3}
-              placeholder="Optional approval note"
-            />
-          </div>
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setReviewTarget(null)}>Cancel</Button>
-            <Button
-              onClick={() => void handleApprovalReview()}
-              disabled={!!reviewTarget && savingTicketId === reviewTarget.ticketId}
-              variant={reviewTarget?.decision === 'rejected' ? 'destructive' : 'default'}
-            >
-              {!!reviewTarget && savingTicketId === reviewTarget.ticketId ? 'Saving...' : reviewTarget?.decision === 'approved' ? 'Approve' : 'Reject'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/src/pages/tickets/RequestReports.tsx
+++ b/src/pages/tickets/RequestReports.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Download, FileSpreadsheet, Printer, Search } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '@/contexts/AuthContext';
 import { STALE } from '@/lib/queryClient';
@@ -16,6 +17,7 @@ import { useRequestCategories } from '@/hooks/useRequestCategories';
 import { getRequestCategoryLabel } from '@/lib/requestCategories';
 import { downloadCsv, formatTicketLabel } from '@/lib/requestFormatters';
 import { formatSlaState, getTicketSlaSummary } from '@/lib/ticketSla';
+import { openTicketWorkspace } from '@/lib/ticketWorkspaceNavigation';
 import { getRequestManagementDashboard } from '@/services/requestManagementService';
 import { listCompanyTickets, type CompanyTicketRecord } from '@/services/ticketService';
 
@@ -46,6 +48,7 @@ const REPORTS: Array<{ value: ReportType; label: string }> = [
 
 interface ReportRow {
   id: string;
+  ticketId?: string;
   request: string;
   category: string;
   owner: string;
@@ -75,6 +78,7 @@ function downloadExcel(filename: string, rows: string[][]) {
 
 export default function RequestReports() {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const { categories } = useRequestCategories(user?.company_id, true);
   const [reportType, setReportType] = useState<ReportType>('sla');
   const [searchTerm, setSearchTerm] = useState('');
@@ -99,6 +103,7 @@ export default function RequestReports() {
     const dashboard = data?.dashboard;
     const base = (ticket: CompanyTicketRecord, metric: string, detail: string): ReportRow => ({
       id: ticket.id,
+      ticketId: ticket.id,
       request: ticket.subject,
       category: getRequestCategoryLabel(ticket.category, categories),
       owner: ticket.assigned_to_name ?? ticket.responsible_queue,
@@ -170,6 +175,7 @@ export default function RequestReports() {
     if (!query) return rows;
     return rows.filter((row) => Object.values(row).join(' ').toLowerCase().includes(query));
   }, [rows, searchTerm]);
+  const hasTicketRows = filteredRows.some((row) => row.ticketId);
 
   const exportRows = useMemo(
     () => [
@@ -246,6 +252,17 @@ export default function RequestReports() {
               hideSearch
               mobileLayout="cards"
               emptyMessage="No rows match this report."
+              onRowClick={hasTicketRows
+                ? (row) => {
+                    if (!row.ticketId) return;
+                    openTicketWorkspace(navigate, row.ticketId, {
+                      source: 'reports',
+                      path: '/portal/reports',
+                      scrollTop: window.scrollY,
+                      filters: { reportType, searchTerm },
+                    });
+                  }
+                : undefined}
             />
           )}
         </CardContent>

--- a/src/pages/tickets/TicketWorkspace.tsx
+++ b/src/pages/tickets/TicketWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ElementType, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ElementType, type ReactNode } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { format, formatDistanceToNow } from 'date-fns';
 import {
@@ -13,7 +13,7 @@ import {
   ShieldAlert,
   UserRound,
 } from 'lucide-react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useBlocker, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { listProfiles } from '@flc/auth';
 import { listAttachmentsForTickets, uploadTicketAttachment, type TicketAttachmentRecord } from '@flc/platform-services';
@@ -45,6 +45,8 @@ import { TicketSlaSummary } from '@/components/tickets/TicketSlaSummary';
 import { useRequestCategories } from '@/hooks/useRequestCategories';
 import { useRequestFormFields } from '@/hooks/useRequestFormFields';
 import { useRequestSubcategories } from '@/hooks/useRequestSubcategories';
+import { useBeforeUnloadWarning } from '@/hooks/useBeforeUnloadWarning';
+import { usePersistedDraftMap } from '@/hooks/usePersistedDraftMap';
 import { STALE } from '@/lib/queryClient';
 import { canManagePortalQueue } from '@/lib/portalAccess';
 import { getRequestAssignees } from '@/lib/requestAssignees';
@@ -115,17 +117,17 @@ function formatDateTime(value: string | null | undefined) {
 
 function InfoRow({ label, value }: { label: string; value: ReactNode }) {
   return (
-    <div className="min-w-0 rounded-md border border-border bg-background px-3 py-2">
-      <p className="text-xs font-medium uppercase text-muted-foreground">{label}</p>
-      <div className="mt-1 break-words text-sm font-medium text-foreground">{value}</div>
+    <div className="min-w-0 rounded-md bg-muted/30 px-3 py-2 ring-1 ring-border/60">
+      <p className="text-[11px] font-semibold uppercase text-muted-foreground">{label}</p>
+      <div className="mt-1 break-words text-sm font-medium leading-5 text-foreground">{value}</div>
     </div>
   );
 }
 
 function Section({ title, icon: Icon, children }: { title: string; icon?: ElementType; children: ReactNode }) {
   return (
-    <section className="rounded-lg border border-border bg-card p-4 shadow-sm">
-      <div className="mb-3 flex items-center gap-2">
+    <section className="rounded-lg bg-card p-4 shadow-sm ring-1 ring-border/70">
+      <div className="mb-3 flex items-center gap-2 border-b border-border/70 pb-2.5">
         {Icon && <Icon className="h-4 w-4 text-muted-foreground" aria-hidden />}
         <h2 className="text-sm font-semibold text-foreground">{title}</h2>
       </div>
@@ -157,6 +159,66 @@ function primaryActionLabel(ticket: CompanyTicketRecord, permissions: TicketWork
   return null;
 }
 
+const workflowSteps: Array<{ status: TicketStatus; label: string }> = [
+  { status: 'open', label: 'Open' },
+  { status: 'in_progress', label: 'In Progress' },
+  { status: 'pending_requester', label: 'Pending Requester' },
+  { status: 'pending_owner_review', label: 'Owner Review' },
+  { status: 'completed_by_owner', label: 'Completed by Owner' },
+  { status: 'closed', label: 'Closed' },
+];
+
+function WorkflowStrip({ status }: { status: TicketStatus }) {
+  const activeIndex = workflowSteps.findIndex((step) => step.status === status);
+  const terminal = status === 'cancelled' || status === 'reopened';
+  return (
+    <div className="overflow-x-auto rounded-md bg-muted/30 px-3 py-2 ring-1 ring-border/60">
+      <div className="flex min-w-max items-center gap-2">
+        {workflowSteps.map((step, index) => {
+          const active = step.status === status;
+          const complete = !terminal && activeIndex >= 0 && index < activeIndex;
+          return (
+            <div key={step.status} className="flex items-center gap-2">
+              <span
+                className={[
+                  'flex h-6 min-w-6 items-center justify-center rounded-full px-2 text-[11px] font-semibold',
+                  active ? 'bg-primary text-primary-foreground' : complete ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300' : 'bg-background text-muted-foreground ring-1 ring-border',
+                ].join(' ')}
+              >
+                {index + 1}
+              </span>
+              <span className={active ? 'text-xs font-semibold text-foreground' : 'text-xs text-muted-foreground'}>{step.label}</span>
+              {index < workflowSteps.length - 1 && <span className="h-px w-6 bg-border" aria-hidden />}
+            </div>
+          );
+        })}
+        {terminal && <Badge variant="outline" className="ml-2 capitalize">{formatTicketLabel(status)}</Badge>}
+      </div>
+    </div>
+  );
+}
+
+function useTicketDraftField(
+  scope: string,
+  ticketId: string,
+  companyId: string | null | undefined,
+  userId: string | null | undefined,
+  fallback = '',
+) {
+  const [drafts, setDrafts, clearDraft] = usePersistedDraftMap(scope, companyId, userId);
+  const hasDraft = Boolean(ticketId) && Object.prototype.hasOwnProperty.call(drafts, ticketId);
+  const value = hasDraft ? drafts[ticketId] : fallback;
+  const setValue = useCallback((nextValue: string) => {
+    if (!ticketId) return;
+    setDrafts((current) => ({ ...current, [ticketId]: nextValue }));
+  }, [setDrafts, ticketId]);
+  const clearValue = useCallback(() => {
+    if (!ticketId) return;
+    clearDraft(ticketId);
+  }, [clearDraft, ticketId]);
+  return { value, setValue, clearValue, hasDraft };
+}
+
 export default function TicketWorkspace() {
   const { ticketId = '' } = useParams();
   const navigate = useNavigate();
@@ -166,8 +228,6 @@ export default function TicketWorkspace() {
   const canManageQueue = canManagePortalQueue(user);
 
   const [saving, setSaving] = useState(false);
-  const [commentDraft, setCommentDraft] = useState('');
-  const [internalNoteDraft, setInternalNoteDraft] = useState('');
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
   const [requesterUpdateOpen, setRequesterUpdateOpen] = useState(false);
   const [completionOpen, setCompletionOpen] = useState(false);
@@ -177,20 +237,13 @@ export default function TicketWorkspace() {
   const [priorityOpen, setPriorityOpen] = useState(false);
   const [overrideOpen, setOverrideOpen] = useState(false);
   const [reviewDecision, setReviewDecision] = useState<'approved' | 'rejected' | null>(null);
-  const [workflowMessage, setWorkflowMessage] = useState('');
-  const [resolutionSummary, setResolutionSummary] = useState('');
   const [completionCategory, setCompletionCategory] = useState<TicketCompletionCategory>('resolved');
   const [completionChecklistConfirmed, setCompletionChecklistConfirmed] = useState(false);
-  const [completionBreachReason, setCompletionBreachReason] = useState('');
   const [closeConfirmed, setCloseConfirmed] = useState(false);
   const [satisfactionRating, setSatisfactionRating] = useState('5');
-  const [closureFeedback, setClosureFeedback] = useState('');
-  const [reopenReason, setReopenReason] = useState('');
   const [selectedAssignee, setSelectedAssignee] = useState('unassigned');
   const [selectedPriority, setSelectedPriority] = useState<TicketPriority>('medium');
   const [overrideStatus, setOverrideStatus] = useState<TicketStatus>('in_progress');
-  const [overrideReason, setOverrideReason] = useState('');
-  const [reviewNote, setReviewNote] = useState('');
 
   const activeTabParam = searchParams.get('tab') as TicketWorkspaceTab | null;
   const visibleTabs = useMemo(
@@ -247,6 +300,27 @@ export default function TicketWorkspace() {
   const ticket = data?.ticket ?? null;
   const sla = ticket ? getTicketSlaSummary(ticket) : null;
   const needsBreachReason = sla?.overall === 'breached' && !ticket?.sla_breach_reason;
+  const chatDraft = useTicketDraftField('workspace:chat', ticketId, user?.company_id, user?.id);
+  const internalNote = useTicketDraftField('workspace:internal-note', ticketId, user?.company_id, user?.id);
+  const workflowMessage = useTicketDraftField('workspace:workflow-message', ticketId, user?.company_id, user?.id);
+  const resolutionDraft = useTicketDraftField('workspace:resolution', ticketId, user?.company_id, user?.id, ticket?.resolution_note ?? '');
+  const breachReason = useTicketDraftField('workspace:breach-reason', ticketId, user?.company_id, user?.id, ticket?.sla_breach_reason ?? '');
+  const closureFeedback = useTicketDraftField('workspace:closure-feedback', ticketId, user?.company_id, user?.id);
+  const reopenReason = useTicketDraftField('workspace:reopen-reason', ticketId, user?.company_id, user?.id);
+  const overrideReason = useTicketDraftField('workspace:override-reason', ticketId, user?.company_id, user?.id);
+  const reviewNote = useTicketDraftField('workspace:review-note', ticketId, user?.company_id, user?.id);
+  const resolutionSummary = resolutionDraft.value;
+  const completionBreachReason = breachReason.value;
+  const resolutionDirty = Boolean(
+    ticket
+    && resolutionDraft.hasDraft
+    && resolutionSummary.trim() !== (ticket.resolution_note ?? '').trim(),
+  );
+  const breachReasonDirty = Boolean(
+    ticket
+    && breachReason.hasDraft
+    && completionBreachReason.trim() !== (ticket.sla_breach_reason ?? '').trim(),
+  );
   const customFieldLabelMap = useMemo(
     () => Object.fromEntries(formFields.map((field) => [`${field.category_key}:${field.key}`, field.label])),
     [formFields],
@@ -257,30 +331,22 @@ export default function TicketWorkspace() {
 
   useEffect(() => {
     if (!ticket) return;
-    setResolutionSummary(ticket.resolution_note ?? '');
-    setCompletionBreachReason(ticket.sla_breach_reason ?? '');
-    setSelectedAssignee(ticket.assigned_to ?? 'unassigned');
-    setSelectedPriority(ticket.priority);
-    setOverrideStatus(ticket.status === 'closed' ? 'in_progress' : ticket.status);
-  }, [ticket]);
-
-  useEffect(() => {
-    if (!user || !ticket || !data?.permissions.canManageWorkflow || ticket.status !== 'open') return;
-    void updateTicket(ticket.id, { mark_opened: true }, { userId: user.id, companyId: user.company_id })
-      .then((result) => {
-        if (result.data) void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-      });
-  }, [data?.permissions.canManageWorkflow, queryClient, ticket, user, workspaceQueryKey]);
+    if (!assignOpen) setSelectedAssignee(ticket.assigned_to ?? 'unassigned');
+    if (!priorityOpen) setSelectedPriority(ticket.priority);
+    if (!overrideOpen) setOverrideStatus(ticket.status === 'closed' ? 'in_progress' : ticket.status);
+  }, [assignOpen, overrideOpen, priorityOpen, ticket]);
 
   useEffect(() => {
     if (!user || !ticket || activeTab !== 'chat') return;
-    void markTicketChatRead(ticket.id, { userId: user.id, companyId: user.company_id })
-      .then(() => void queryClient.invalidateQueries({ queryKey: workspaceQueryKey }));
-  }, [activeTab, queryClient, ticket, user, workspaceQueryKey]);
+    void markTicketChatRead(ticket.id, { userId: user.id, companyId: user.company_id });
+  }, [activeTab, ticket, user]);
 
-  const refreshWorkspace = () => queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+  const refreshWorkspace = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: workspaceQueryKey }),
+    [queryClient, workspaceQueryKey],
+  );
 
-  const runWorkflow = async (operation: () => Promise<{ error: Error | string | null }>, successMessage: string) => {
+  const runWorkflow = useCallback(async (operation: () => Promise<{ error: Error | string | null }>, successMessage: string) => {
     setSaving(true);
     const result = await operation();
     setSaving(false);
@@ -291,7 +357,7 @@ export default function TicketWorkspace() {
     toast.success(successMessage);
     await refreshWorkspace();
     return true;
-  };
+  }, [refreshWorkspace]);
 
   const handleBack = () => {
     if (!ticket) {
@@ -340,15 +406,16 @@ export default function TicketWorkspace() {
     }
   };
 
-  const handleAddComment = async () => {
-    if (!ticket || !user || !commentDraft.trim()) return;
-    const message = commentDraft.trim();
+  const handleAddComment = useCallback(async () => {
+    const message = chatDraft.value.trim();
+    if (!ticket || !user || !message) return true;
     const ok = await runWorkflow(
       () => addTicketComment(ticket.id, { message }, { userId: user.id, companyId: user.company_id }),
       'Message sent',
     );
-    if (ok) setCommentDraft('');
-  };
+    if (ok) chatDraft.clearValue();
+    return ok;
+  }, [chatDraft, runWorkflow, ticket, user]);
 
   const handleChatFilesSelected = async (files: File[]) => {
     if (!ticket || !user || files.length === 0) return;
@@ -368,14 +435,125 @@ export default function TicketWorkspace() {
     await refreshWorkspace();
   };
 
-  const handleAddInternalNote = async () => {
-    if (!ticket || !user || !internalNoteDraft.trim()) return;
-    const note = internalNoteDraft.trim();
+  const handleAddInternalNote = useCallback(async () => {
+    const note = internalNote.value.trim();
+    if (!ticket || !user || !note) return true;
     const ok = await runWorkflow(
       () => addTicketInternalNote(ticket.id, { note }, { userId: user.id, companyId: user.company_id }),
       'Internal note added',
     );
-    if (ok) setInternalNoteDraft('');
+    if (ok) internalNote.clearValue();
+    return ok;
+  }, [internalNote, runWorkflow, ticket, user]);
+
+  const hasUnsavedChanges = Boolean(
+    chatDraft.value.trim()
+    || internalNote.value.trim()
+    || workflowMessage.value.trim()
+    || closureFeedback.value.trim()
+    || reopenReason.value.trim()
+    || overrideReason.value.trim()
+    || reviewNote.value.trim()
+    || resolutionDirty
+    || breachReasonDirty
+    || (closeOpen && closeConfirmed)
+    || (ticket && assignOpen && selectedAssignee !== (ticket.assigned_to ?? 'unassigned'))
+    || (ticket && priorityOpen && selectedPriority !== ticket.priority)
+    || (ticket && overrideOpen && overrideStatus !== (ticket.status === 'closed' ? 'in_progress' : ticket.status))
+  );
+
+  useBeforeUnloadWarning(hasUnsavedChanges);
+
+  const blocker = useBlocker(({ currentLocation, nextLocation }) => (
+    hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname
+  ));
+
+  const discardWorkspaceChanges = useCallback(() => {
+    chatDraft.clearValue();
+    internalNote.clearValue();
+    workflowMessage.clearValue();
+    resolutionDraft.clearValue();
+    breachReason.clearValue();
+    closureFeedback.clearValue();
+    reopenReason.clearValue();
+    overrideReason.clearValue();
+    reviewNote.clearValue();
+    setCompletionChecklistConfirmed(false);
+    setCloseConfirmed(false);
+    if (ticket) {
+      setSelectedAssignee(ticket.assigned_to ?? 'unassigned');
+      setSelectedPriority(ticket.priority);
+      setOverrideStatus(ticket.status === 'closed' ? 'in_progress' : ticket.status);
+    }
+  }, [breachReason, chatDraft, closureFeedback, internalNote, overrideReason, reopenReason, resolutionDraft, reviewNote, ticket, workflowMessage]);
+
+  const saveWorkspaceChanges = useCallback(async () => {
+    if (!ticket || !user) {
+      toast.error('Unable to save changes without an active request session.');
+      return false;
+    }
+
+    let ok = true;
+    if (chatDraft.value.trim()) ok = (await handleAddComment()) && ok;
+    if (internalNote.value.trim()) ok = (await handleAddInternalNote()) && ok;
+
+    if (resolutionDirty || breachReasonDirty) {
+      const result = await runWorkflow(
+        () => updateTicket(
+          ticket.id,
+          {
+            ...(resolutionDirty ? { resolution_note: resolutionSummary } : {}),
+            ...(breachReasonDirty ? { sla_breach_reason: completionBreachReason } : {}),
+          },
+          { userId: user.id, companyId: user.company_id },
+        ),
+        'Workspace fields saved',
+      );
+      if (result) {
+        resolutionDraft.clearValue();
+        breachReason.clearValue();
+      }
+      ok = result && ok;
+    }
+
+    if (ok && (
+      workflowMessage.value.trim()
+      || closureFeedback.value.trim()
+      || reopenReason.value.trim()
+      || overrideReason.value.trim()
+      || reviewNote.value.trim()
+    )) {
+      toast.info('Workflow dialog text is saved as a local draft until you submit that action.');
+    }
+
+    return ok;
+  }, [
+    breachReason,
+    breachReasonDirty,
+    chatDraft.value,
+    closureFeedback.value,
+    completionBreachReason,
+    handleAddComment,
+    handleAddInternalNote,
+    internalNote.value,
+    overrideReason.value,
+    reopenReason.value,
+    resolutionDirty,
+    resolutionDraft,
+    resolutionSummary,
+    reviewNote.value,
+    runWorkflow,
+    ticket,
+    user,
+    workflowMessage.value,
+  ]);
+
+  const requestRefreshWorkspace = () => {
+    if (hasUnsavedChanges) {
+      toast.info('Save or discard workspace changes before refreshing.');
+      return;
+    }
+    void refreshWorkspace();
   };
 
   if (isLoading) {
@@ -448,7 +626,7 @@ export default function TicketWorkspace() {
                     </>
                   )}
                   {data.permissions.canViewAuditTrail && <DropdownMenuItem onClick={() => setTab('audit-trail')}>View audit trail</DropdownMenuItem>}
-                  <DropdownMenuItem onClick={() => void refreshWorkspace()}>Refresh workspace</DropdownMenuItem>
+                  <DropdownMenuItem onClick={requestRefreshWorkspace}>Refresh workspace</DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
@@ -466,36 +644,39 @@ export default function TicketWorkspace() {
         )}
 
         <div className="sticky top-[96px] z-10 rounded-lg border border-border bg-background/95 p-3 shadow-sm backdrop-blur">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-            <div className="grid gap-2 text-sm md:grid-cols-3 lg:flex lg:flex-wrap">
-              <InfoRow label="Responsible party" value={ticket.current_responsible_party} />
-              <InfoRow label="Next action" value={ticket.next_action} />
-              <InfoRow label="SLA status" value={sla ? formatTicketLabel(sla.overall) : 'Not configured'} />
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {data.permissions.canReviewApproval && (
-                <>
-                  <Button type="button" variant="outline" className="gap-1.5" onClick={() => setReviewDecision('approved')} disabled={saving}>
-                    <CheckCircle2 className="h-4 w-4" />
-                    Approve
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div className="grid gap-2 text-sm md:grid-cols-3 lg:flex lg:flex-wrap">
+                <InfoRow label="Responsible party" value={ticket.current_responsible_party} />
+                <InfoRow label="Next action" value={ticket.next_action} />
+                <InfoRow label="SLA status" value={sla ? formatTicketLabel(sla.overall) : 'Not configured'} />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {data.permissions.canReviewApproval && (
+                  <>
+                    <Button type="button" variant="outline" className="gap-1.5" onClick={() => setReviewDecision('approved')} disabled={saving}>
+                      <CheckCircle2 className="h-4 w-4" />
+                      Approve
+                    </Button>
+                    <Button type="button" variant="outline" className="gap-1.5 border-red-300 text-red-700 hover:bg-red-50 hover:text-red-800" onClick={() => setReviewDecision('rejected')} disabled={saving}>
+                      Reject
+                    </Button>
+                  </>
+                )}
+                {data.permissions.canManageWorkflow && (
+                  <Button type="button" variant="outline" onClick={() => setInfoDialogOpen(true)} disabled={saving || ticket.status === 'closed' || ticket.status === 'cancelled'}>
+                    Request More Info
                   </Button>
-                  <Button type="button" variant="outline" className="gap-1.5 border-red-300 text-red-700 hover:bg-red-50 hover:text-red-800" onClick={() => setReviewDecision('rejected')} disabled={saving}>
-                    Reject
+                )}
+                {primaryLabel && (
+                  <Button type="button" onClick={() => void handlePrimaryAction()} disabled={saving}>
+                    {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                    {primaryLabel}
                   </Button>
-                </>
-              )}
-              {data.permissions.canManageWorkflow && (
-                <Button type="button" variant="outline" onClick={() => setInfoDialogOpen(true)} disabled={saving || ticket.status === 'closed' || ticket.status === 'cancelled'}>
-                  Request More Info
-                </Button>
-              )}
-              {primaryLabel && (
-                <Button type="button" onClick={() => void handlePrimaryAction()} disabled={saving}>
-                  {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-                  {primaryLabel}
-                </Button>
-              )}
+                )}
+              </div>
             </div>
+            <WorkflowStrip status={ticket.status} />
           </div>
         </div>
 
@@ -578,9 +759,9 @@ export default function TicketWorkspace() {
                 <TicketChatPanel
                   activities={data.activities}
                   currentUserId={user?.id}
-                  draft={commentDraft}
+                  draft={chatDraft.value}
                   saving={saving}
-                  onDraftChange={setCommentDraft}
+                  onDraftChange={chatDraft.setValue}
                   onSend={() => void handleAddComment()}
                   onAttachFiles={(files) => void handleChatFilesSelected(files)}
                 />
@@ -612,9 +793,9 @@ export default function TicketWorkspace() {
                 <TabsContent value="internal-notes">
                   <TicketInternalNotesPanel
                     notes={data.internalNotes}
-                    draft={internalNoteDraft}
+                    draft={internalNote.value}
                     saving={saving}
-                    onDraftChange={setInternalNoteDraft}
+                    onDraftChange={internalNote.setValue}
                     onSend={() => void handleAddInternalNote()}
                   />
                 </TabsContent>
@@ -639,6 +820,10 @@ export default function TicketWorkspace() {
               <div className="space-y-2">
                 <InfoRow label="Requester" value={ticket.submitted_by_name ?? ticket.submitted_by_email ?? 'Unknown'} />
                 <InfoRow label="Owner / PIC" value={ticket.assigned_to_name ?? ticket.responsible_queue} />
+                <InfoRow label="Category" value={getRequestCategoryLabel(ticket.category, categories)} />
+                <InfoRow label="Subcategory" value={ticket.subcategory ? getRequestSubcategoryLabel(ticket.subcategory, ticket.category, subcategories) : 'Not selected'} />
+                <InfoRow label="Priority" value={formatTicketLabel(ticket.priority)} />
+                <InfoRow label="Next action" value={ticket.next_action} />
                 <InfoRow label="Backup owner" value={ticket.backup_owner_name ?? 'Not assigned'} />
                 <InfoRow label="Escalation owner" value={ticket.escalation_owner_name ?? 'Not assigned'} />
                 <InfoRow label="Last action by" value={ticket.last_action_by_name ?? 'System'} />
@@ -648,6 +833,8 @@ export default function TicketWorkspace() {
             <TicketOperationalIndicatorGrid indicator={data.operationalIndicator} />
             <Section title="Accountability">
               <div className="space-y-2">
+                <InfoRow label="First response due" value={formatDateTime(ticket.first_response_due_at)} />
+                <InfoRow label="Resolution due" value={formatDateTime(ticket.resolution_due_at)} />
                 <InfoRow label="Time in current status" value={formatDistanceToNow(new Date(ticket.status_changed_at), { addSuffix: false })} />
                 <InfoRow label="Request age" value={formatDistanceToNow(new Date(ticket.created_at), { addSuffix: false })} />
                 <InfoRow label="Chat messages" value={String(data.chatSummary.message_count)} />
@@ -662,18 +849,18 @@ export default function TicketWorkspace() {
         open={infoDialogOpen}
         title="Request more information"
         description="This moves the request to Pending Requester and records the message in chat."
-        value={workflowMessage}
-        onValueChange={setWorkflowMessage}
+        value={workflowMessage.value}
+        onValueChange={workflowMessage.setValue}
         saving={saving}
-        onOpenChange={(open) => { setInfoDialogOpen(open); if (!open) setWorkflowMessage(''); }}
+        onOpenChange={setInfoDialogOpen}
         onSubmit={async () => {
-          if (!user || !workflowMessage.trim()) return;
+          if (!user || !workflowMessage.value.trim()) return;
           const ok = await runWorkflow(
-            () => requestTicketMoreInformation(ticket.id, { message: workflowMessage.trim() }, { userId: user.id, companyId: user.company_id }),
+            () => requestTicketMoreInformation(ticket.id, { message: workflowMessage.value.trim() }, { userId: user.id, companyId: user.company_id }),
             'Information requested',
           );
           if (ok) {
-            setWorkflowMessage('');
+            workflowMessage.clearValue();
             setInfoDialogOpen(false);
           }
         }}
@@ -683,18 +870,18 @@ export default function TicketWorkspace() {
         open={requesterUpdateOpen}
         title="Submit update"
         description="This moves the request to Pending Owner Review."
-        value={workflowMessage}
-        onValueChange={setWorkflowMessage}
+        value={workflowMessage.value}
+        onValueChange={workflowMessage.setValue}
         saving={saving}
-        onOpenChange={(open) => { setRequesterUpdateOpen(open); if (!open) setWorkflowMessage(''); }}
+        onOpenChange={setRequesterUpdateOpen}
         onSubmit={async () => {
-          if (!user || !workflowMessage.trim()) return;
+          if (!user || !workflowMessage.value.trim()) return;
           const ok = await runWorkflow(
-            () => submitRequesterTicketUpdate(ticket.id, { message: workflowMessage.trim() }, { userId: user.id, companyId: user.company_id }),
+            () => submitRequesterTicketUpdate(ticket.id, { message: workflowMessage.value.trim() }, { userId: user.id, companyId: user.company_id }),
             'Update submitted',
           );
           if (ok) {
-            setWorkflowMessage('');
+            workflowMessage.clearValue();
             setRequesterUpdateOpen(false);
           }
         }}
@@ -709,7 +896,7 @@ export default function TicketWorkspace() {
           <div className="space-y-4">
             <div className="space-y-1.5">
               <Label htmlFor="resolution-summary">Resolution summary</Label>
-              <Textarea id="resolution-summary" value={resolutionSummary} onChange={(event) => setResolutionSummary(event.target.value)} rows={4} />
+              <Textarea id="resolution-summary" value={resolutionSummary} onChange={(event) => resolutionDraft.setValue(event.target.value)} rows={4} />
             </div>
             <div className="space-y-1.5">
               <Label>Completion category</Label>
@@ -727,7 +914,7 @@ export default function TicketWorkspace() {
             {needsBreachReason && (
               <div className="space-y-1.5">
                 <Label htmlFor="breach-reason">Breach reason</Label>
-                <Textarea id="breach-reason" value={completionBreachReason} onChange={(event) => setCompletionBreachReason(event.target.value)} rows={3} />
+                <Textarea id="breach-reason" value={completionBreachReason} onChange={(event) => breachReason.setValue(event.target.value)} rows={3} />
               </div>
             )}
             <label htmlFor="completion-checklist" className="flex items-start gap-2 rounded-md border border-border px-3 py-2 text-sm">
@@ -755,7 +942,11 @@ export default function TicketWorkspace() {
                   ),
                   'Request marked completed',
                 );
-                if (ok) setCompletionOpen(false);
+                if (ok) {
+                  resolutionDraft.clearValue();
+                  breachReason.clearValue();
+                  setCompletionOpen(false);
+                }
               }}
             >
               Mark completed
@@ -784,7 +975,7 @@ export default function TicketWorkspace() {
                 </SelectContent>
               </Select>
             </div>
-            <Textarea value={closureFeedback} onChange={(event) => setClosureFeedback(event.target.value)} rows={3} placeholder="Optional feedback" />
+            <Textarea value={closureFeedback.value} onChange={(event) => closureFeedback.setValue(event.target.value)} rows={3} placeholder="Optional feedback" />
           </div>
           <DialogFooter>
             <Button type="button" variant="ghost" onClick={() => setCloseOpen(false)}>Cancel</Button>
@@ -796,12 +987,15 @@ export default function TicketWorkspace() {
                 const ok = await runWorkflow(
                   () => closeTicketByRequester(
                     ticket.id,
-                    { confirmedResolved: closeConfirmed, satisfactionRating: Number(satisfactionRating), feedbackComment: closureFeedback },
+                    { confirmedResolved: closeConfirmed, satisfactionRating: Number(satisfactionRating), feedbackComment: closureFeedback.value },
                     { userId: user.id, companyId: user.company_id },
                   ),
                   'Request closed',
                 );
-                if (ok) setCloseOpen(false);
+                if (ok) {
+                  closureFeedback.clearValue();
+                  setCloseOpen(false);
+                }
               }}
             >
               Close request
@@ -814,18 +1008,18 @@ export default function TicketWorkspace() {
         open={reopenOpen}
         title="Reopen request"
         description="Provide the reason so the owner understands what needs attention."
-        value={reopenReason}
-        onValueChange={setReopenReason}
+        value={reopenReason.value}
+        onValueChange={reopenReason.setValue}
         saving={saving}
-        onOpenChange={(open) => { setReopenOpen(open); if (!open) setReopenReason(''); }}
+        onOpenChange={setReopenOpen}
         onSubmit={async () => {
-          if (!user || !reopenReason.trim()) return;
+          if (!user || !reopenReason.value.trim()) return;
           const ok = await runWorkflow(
-            () => reopenTicketByRequester(ticket.id, { reason: reopenReason }, { userId: user.id, companyId: user.company_id }),
+            () => reopenTicketByRequester(ticket.id, { reason: reopenReason.value }, { userId: user.id, companyId: user.company_id }),
             'Request reopened',
           );
           if (ok) {
-            setReopenReason('');
+            reopenReason.clearValue();
             setReopenOpen(false);
           }
         }}
@@ -898,7 +1092,7 @@ export default function TicketWorkspace() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={overrideOpen} onOpenChange={(open) => { setOverrideOpen(open); if (!open) setOverrideReason(''); }}>
+      <Dialog open={overrideOpen} onOpenChange={setOverrideOpen}>
         <DialogContent className="max-w-md">
           <DialogHeader>
             <DialogTitle>Admin override status</DialogTitle>
@@ -911,21 +1105,21 @@ export default function TicketWorkspace() {
                 {statusOptions.map((option) => <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>)}
               </SelectContent>
             </Select>
-            <Textarea value={overrideReason} onChange={(event) => setOverrideReason(event.target.value)} rows={3} placeholder="Required reason" />
+            <Textarea value={overrideReason.value} onChange={(event) => overrideReason.setValue(event.target.value)} rows={3} placeholder="Required reason" />
           </div>
           <DialogFooter>
             <Button type="button" variant="ghost" onClick={() => setOverrideOpen(false)}>Cancel</Button>
             <Button
               type="button"
-              disabled={saving || !overrideReason.trim()}
+              disabled={saving || !overrideReason.value.trim()}
               onClick={async () => {
                 if (!user) return;
                 const ok = await runWorkflow(
-                  () => updateTicket(ticket.id, { status: overrideStatus, admin_override_reason: overrideReason }, { userId: user.id, companyId: user.company_id }),
+                  () => updateTicket(ticket.id, { status: overrideStatus, admin_override_reason: overrideReason.value }, { userId: user.id, companyId: user.company_id }),
                   'Status overridden',
                 );
                 if (ok) {
-                  setOverrideReason('');
+                  overrideReason.clearValue();
                   setOverrideOpen(false);
                 }
               }}
@@ -936,13 +1130,13 @@ export default function TicketWorkspace() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={reviewDecision !== null} onOpenChange={(open) => { if (!open) { setReviewDecision(null); setReviewNote(''); } }}>
+      <Dialog open={reviewDecision !== null} onOpenChange={(open) => { if (!open) setReviewDecision(null); }}>
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle>{reviewDecision === 'approved' ? 'Approve request' : 'Reject request'}</DialogTitle>
             <DialogDescription>{reviewDecision === 'approved' ? 'Record approval for the current step.' : 'Rejecting approval may stop the request workflow.'}</DialogDescription>
           </DialogHeader>
-          <Textarea value={reviewNote} onChange={(event) => setReviewNote(event.target.value)} rows={3} placeholder="Optional note" />
+          <Textarea value={reviewNote.value} onChange={(event) => reviewNote.setValue(event.target.value)} rows={3} placeholder="Optional note" />
           <DialogFooter>
             <Button type="button" variant="ghost" onClick={() => setReviewDecision(null)}>Cancel</Button>
             <Button
@@ -952,18 +1146,60 @@ export default function TicketWorkspace() {
                 if (!user || !reviewDecision) return;
                 const decision = reviewDecision;
                 const ok = await runWorkflow(
-                  () => reviewInternalRequestApproval(ticket.id, decision, reviewNote, { userId: user.id, companyId: user.company_id })
+                  () => reviewInternalRequestApproval(ticket.id, decision, reviewNote.value, { userId: user.id, companyId: user.company_id })
                     .then((result) => ({ error: result.error ? new Error(result.error) : null })),
                   decision === 'approved' ? 'Approval recorded' : 'Rejection recorded',
                 );
                 if (ok) {
                   setReviewDecision(null);
-                  setReviewNote('');
+                  reviewNote.clearValue();
                 }
               }}
             >
               {reviewDecision === 'approved' ? 'Approve' : 'Reject'}
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={blocker.state === 'blocked'} onOpenChange={(open) => { if (!open && blocker.state === 'blocked') blocker.reset(); }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Unsaved workspace changes</DialogTitle>
+            <DialogDescription>
+              Save fields that can be persisted now, discard local drafts, or keep editing this request.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="rounded-md bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+            Workflow action text is kept as a local draft until you submit that action.
+          </div>
+          <DialogFooter className="gap-2 sm:justify-between">
+            <Button type="button" variant="ghost" onClick={() => blocker.state === 'blocked' && blocker.reset()}>
+              Continue editing
+            </Button>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  discardWorkspaceChanges();
+                  if (blocker.state === 'blocked') blocker.proceed();
+                }}
+              >
+                Discard
+              </Button>
+              <Button
+                type="button"
+                disabled={saving}
+                onClick={async () => {
+                  const ok = await saveWorkspaceChanges();
+                  if (ok && blocker.state === 'blocked') blocker.proceed();
+                }}
+              >
+                {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                Save
+              </Button>
+            </div>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/pages/tickets/TicketWorkspace.tsx
+++ b/src/pages/tickets/TicketWorkspace.tsx
@@ -1,0 +1,1055 @@
+import { useEffect, useMemo, useState, type ElementType, type ReactNode } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { format, formatDistanceToNow } from 'date-fns';
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  Clock3,
+  FileText,
+  Loader2,
+  MessageSquare,
+  MoreHorizontal,
+  ShieldAlert,
+  UserRound,
+} from 'lucide-react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
+import { listProfiles } from '@flc/auth';
+import { listAttachmentsForTickets, uploadTicketAttachment, type TicketAttachmentRecord } from '@flc/platform-services';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import { HrmsEmptyState } from '@/components/shared/HrmsEmptyState';
+import { RequestPriorityBadge, RequestStatusBadge } from '@/components/tickets/RequestBadge';
+import { TicketActivityList } from '@/components/tickets/TicketActivityList';
+import { TicketAttachmentList } from '@/components/tickets/TicketAttachmentList';
+import { TicketChatPanel } from '@/components/tickets/TicketChatPanel';
+import { TicketInternalNotesPanel } from '@/components/tickets/TicketInternalNotesPanel';
+import { TicketOperationalIndicatorGrid } from '@/components/tickets/TicketOperationalIndicators';
+import { TicketSlaSummary } from '@/components/tickets/TicketSlaSummary';
+import { useRequestCategories } from '@/hooks/useRequestCategories';
+import { useRequestFormFields } from '@/hooks/useRequestFormFields';
+import { useRequestSubcategories } from '@/hooks/useRequestSubcategories';
+import { STALE } from '@/lib/queryClient';
+import { canManagePortalQueue } from '@/lib/portalAccess';
+import { getRequestAssignees } from '@/lib/requestAssignees';
+import { getRequestCategoryLabel } from '@/lib/requestCategories';
+import { customFieldEntries, formatDueDate, formatTicketLabel } from '@/lib/requestFormatters';
+import { getRequestSubcategoryLabel } from '@/lib/requestSubcategories';
+import { getTicketSlaSummary } from '@/lib/ticketSla';
+import {
+  getFallbackTicketListPath,
+  readTicketWorkspaceReturnState,
+  type TicketWorkspaceTab,
+} from '@/lib/ticketWorkspaceNavigation';
+import { buildRequestOperationalIndicators } from '@/services/requestManagementService';
+import { reviewInternalRequestApproval } from '@flc/internal-requests';
+import {
+  addTicketComment,
+  addTicketInternalNote,
+  closeTicketByRequester,
+  getTicketWorkspaceData,
+  markTicketChatRead,
+  markTicketCompletedByOwner,
+  reopenTicketByRequester,
+  requestTicketMoreInformation,
+  submitRequesterTicketUpdate,
+  updateTicket,
+  type CompanyTicketRecord,
+  type TicketAuditEntryRecord,
+  type TicketCompletionCategory,
+  type TicketPriority,
+  type TicketStatus,
+  type TicketWorkspaceData,
+} from '@/services/ticketService';
+
+const tabs: Array<{ value: TicketWorkspaceTab; label: string }> = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'details', label: 'Details' },
+  { value: 'chat', label: 'Chat' },
+  { value: 'attachments', label: 'Attachments' },
+  { value: 'resolution', label: 'Resolution' },
+  { value: 'internal-notes', label: 'Internal Notes' },
+  { value: 'activity', label: 'Activity' },
+  { value: 'audit-trail', label: 'Audit Trail' },
+];
+
+const priorityOptions: Array<{ value: TicketPriority; label: string }> = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+
+const statusOptions: Array<{ value: TicketStatus; label: string }> = [
+  { value: 'open', label: 'Open' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'pending_requester', label: 'Pending Requester' },
+  { value: 'pending_owner_review', label: 'Pending Owner Review' },
+  { value: 'completed_by_owner', label: 'Completed by Owner' },
+  { value: 'closed', label: 'Closed' },
+  { value: 'reopened', label: 'Reopened' },
+  { value: 'cancelled', label: 'Cancelled' },
+];
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return 'Not available';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Not available';
+  return format(date, 'PP p');
+}
+
+function InfoRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="min-w-0 rounded-md border border-border bg-background px-3 py-2">
+      <p className="text-xs font-medium uppercase text-muted-foreground">{label}</p>
+      <div className="mt-1 break-words text-sm font-medium text-foreground">{value}</div>
+    </div>
+  );
+}
+
+function Section({ title, icon: Icon, children }: { title: string; icon?: ElementType; children: ReactNode }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-4 shadow-sm">
+      <div className="mb-3 flex items-center gap-2">
+        {Icon && <Icon className="h-4 w-4 text-muted-foreground" aria-hidden />}
+        <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function EmptyPanel({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-muted/20 px-4 py-8 text-center">
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+function primaryActionLabel(ticket: CompanyTicketRecord, permissions: TicketWorkspaceData['permissions']) {
+  if (permissions.canManageWorkflow) {
+    if (ticket.status === 'open') return 'Start Request';
+    if (ticket.status === 'in_progress' || ticket.status === 'pending_owner_review' || ticket.status === 'reopened') return 'Mark as Completed';
+    if (ticket.status === 'pending_requester') return 'Request More Info';
+  }
+  if (permissions.canCloseAsRequester) {
+    if (ticket.status === 'pending_requester') return 'Submit Update';
+    if (ticket.status === 'completed_by_owner') return 'Close Request';
+    if (ticket.status === 'closed') return 'Reopen Request';
+  }
+  return null;
+}
+
+export default function TicketWorkspace() {
+  const { ticketId = '' } = useParams();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const canManageQueue = canManagePortalQueue(user);
+
+  const [saving, setSaving] = useState(false);
+  const [commentDraft, setCommentDraft] = useState('');
+  const [internalNoteDraft, setInternalNoteDraft] = useState('');
+  const [infoDialogOpen, setInfoDialogOpen] = useState(false);
+  const [requesterUpdateOpen, setRequesterUpdateOpen] = useState(false);
+  const [completionOpen, setCompletionOpen] = useState(false);
+  const [closeOpen, setCloseOpen] = useState(false);
+  const [reopenOpen, setReopenOpen] = useState(false);
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [priorityOpen, setPriorityOpen] = useState(false);
+  const [overrideOpen, setOverrideOpen] = useState(false);
+  const [reviewDecision, setReviewDecision] = useState<'approved' | 'rejected' | null>(null);
+  const [workflowMessage, setWorkflowMessage] = useState('');
+  const [resolutionSummary, setResolutionSummary] = useState('');
+  const [completionCategory, setCompletionCategory] = useState<TicketCompletionCategory>('resolved');
+  const [completionChecklistConfirmed, setCompletionChecklistConfirmed] = useState(false);
+  const [completionBreachReason, setCompletionBreachReason] = useState('');
+  const [closeConfirmed, setCloseConfirmed] = useState(false);
+  const [satisfactionRating, setSatisfactionRating] = useState('5');
+  const [closureFeedback, setClosureFeedback] = useState('');
+  const [reopenReason, setReopenReason] = useState('');
+  const [selectedAssignee, setSelectedAssignee] = useState('unassigned');
+  const [selectedPriority, setSelectedPriority] = useState<TicketPriority>('medium');
+  const [overrideStatus, setOverrideStatus] = useState<TicketStatus>('in_progress');
+  const [overrideReason, setOverrideReason] = useState('');
+  const [reviewNote, setReviewNote] = useState('');
+
+  const activeTabParam = searchParams.get('tab') as TicketWorkspaceTab | null;
+  const visibleTabs = useMemo(
+    () => tabs.filter((tab) => {
+      if (tab.value === 'internal-notes' || tab.value === 'audit-trail') return canManageQueue;
+      return true;
+    }),
+    [canManageQueue],
+  );
+  const activeTab = visibleTabs.some((tab) => tab.value === activeTabParam) ? activeTabParam! : 'overview';
+
+  const { categories } = useRequestCategories(user?.company_id, true);
+  const { subcategories } = useRequestSubcategories(user?.company_id, { includeInactive: true });
+  const { fields: formFields } = useRequestFormFields(user?.company_id, { includeInactive: true });
+
+  const workspaceQueryKey = useMemo(
+    () => ['ticket-workspace', ticketId, user?.id, user?.company_id] as const,
+    [ticketId, user?.company_id, user?.id],
+  );
+  const { data, isLoading, error } = useQuery({
+    queryKey: workspaceQueryKey,
+    enabled: Boolean(user && ticketId),
+    staleTime: STALE.transactional,
+    queryFn: async () => {
+      const result = await getTicketWorkspaceData(ticketId, {
+        userId: user!.id,
+        companyId: user!.company_id,
+        userRole: user!.role,
+        canManagePortalQueue: canManageQueue,
+      });
+      if (result.error || !result.data) throw result.error ?? new Error('Unable to load request workspace.');
+
+      const [{ data: attachmentData }, profileResult] = await Promise.all([
+        listAttachmentsForTickets([ticketId], user!.company_id),
+        listProfiles(user!.company_id),
+      ]);
+      if (profileResult.error) throw new Error(profileResult.error);
+
+      const operationalIndicators = buildRequestOperationalIndicators(
+        [result.data.ticket],
+        { [ticketId]: result.data.activities },
+        { [ticketId]: result.data.chatSummary },
+      );
+
+      return {
+        ...result.data,
+        attachments: attachmentData?.[ticketId] ?? ([] as TicketAttachmentRecord[]),
+        assignees: getRequestAssignees(profileResult.data),
+        operationalIndicator: operationalIndicators[ticketId],
+      };
+    },
+  });
+
+  const ticket = data?.ticket ?? null;
+  const sla = ticket ? getTicketSlaSummary(ticket) : null;
+  const needsBreachReason = sla?.overall === 'breached' && !ticket?.sla_breach_reason;
+  const customFieldLabelMap = useMemo(
+    () => Object.fromEntries(formFields.map((field) => [`${field.category_key}:${field.key}`, field.label])),
+    [formFields],
+  );
+  const customFields = ticket ? customFieldEntries(ticket, customFieldLabelMap) : [];
+  const latestChatMessage = data?.activities.find((activity) => activity.event_type === 'comment_added') ?? null;
+  const latestSystemActivity = data?.activities.find((activity) => activity.event_type !== 'comment_added') ?? null;
+
+  useEffect(() => {
+    if (!ticket) return;
+    setResolutionSummary(ticket.resolution_note ?? '');
+    setCompletionBreachReason(ticket.sla_breach_reason ?? '');
+    setSelectedAssignee(ticket.assigned_to ?? 'unassigned');
+    setSelectedPriority(ticket.priority);
+    setOverrideStatus(ticket.status === 'closed' ? 'in_progress' : ticket.status);
+  }, [ticket]);
+
+  useEffect(() => {
+    if (!user || !ticket || !data?.permissions.canManageWorkflow || ticket.status !== 'open') return;
+    void updateTicket(ticket.id, { mark_opened: true }, { userId: user.id, companyId: user.company_id })
+      .then((result) => {
+        if (result.data) void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+      });
+  }, [data?.permissions.canManageWorkflow, queryClient, ticket, user, workspaceQueryKey]);
+
+  useEffect(() => {
+    if (!user || !ticket || activeTab !== 'chat') return;
+    void markTicketChatRead(ticket.id, { userId: user.id, companyId: user.company_id })
+      .then(() => void queryClient.invalidateQueries({ queryKey: workspaceQueryKey }));
+  }, [activeTab, queryClient, ticket, user, workspaceQueryKey]);
+
+  const refreshWorkspace = () => queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+
+  const runWorkflow = async (operation: () => Promise<{ error: Error | string | null }>, successMessage: string) => {
+    setSaving(true);
+    const result = await operation();
+    setSaving(false);
+    if (result.error) {
+      toast.error(typeof result.error === 'string' ? result.error : result.error.message);
+      return false;
+    }
+    toast.success(successMessage);
+    await refreshWorkspace();
+    return true;
+  };
+
+  const handleBack = () => {
+    if (!ticket) {
+      navigate('/portal/tickets');
+      return;
+    }
+    const state = readTicketWorkspaceReturnState(ticket.id);
+    if (state) {
+      navigate(state.path, { state: { ticketWorkspaceReturnState: state } });
+      return;
+    }
+    navigate(getFallbackTicketListPath(canManageQueue, ticket.status === 'closed'));
+  };
+
+  const setTab = (nextTab: string) => {
+    setSearchParams(nextTab === 'overview' ? {} : { tab: nextTab });
+  };
+
+  const handlePrimaryAction = async () => {
+    if (!ticket || !user || !data) return;
+    if (data.permissions.canManageWorkflow && ticket.status === 'open') {
+      await runWorkflow(
+        () => updateTicket(ticket.id, { mark_opened: true }, { userId: user.id, companyId: user.company_id }),
+        'Request started',
+      );
+      return;
+    }
+    if (data.permissions.canManageWorkflow && (ticket.status === 'in_progress' || ticket.status === 'pending_owner_review' || ticket.status === 'reopened')) {
+      setCompletionOpen(true);
+      return;
+    }
+    if (data.permissions.canManageWorkflow && ticket.status === 'pending_requester') {
+      setInfoDialogOpen(true);
+      return;
+    }
+    if (data.permissions.canCloseAsRequester && ticket.status === 'pending_requester') {
+      setRequesterUpdateOpen(true);
+      return;
+    }
+    if (data.permissions.canCloseAsRequester && ticket.status === 'completed_by_owner') {
+      setCloseOpen(true);
+      return;
+    }
+    if (data.permissions.canCloseAsRequester && ticket.status === 'closed') {
+      setReopenOpen(true);
+    }
+  };
+
+  const handleAddComment = async () => {
+    if (!ticket || !user || !commentDraft.trim()) return;
+    const message = commentDraft.trim();
+    const ok = await runWorkflow(
+      () => addTicketComment(ticket.id, { message }, { userId: user.id, companyId: user.company_id }),
+      'Message sent',
+    );
+    if (ok) setCommentDraft('');
+  };
+
+  const handleChatFilesSelected = async (files: File[]) => {
+    if (!ticket || !user || files.length === 0) return;
+    setSaving(true);
+    const results = await Promise.all(files.map((file) => uploadTicketAttachment(file, ticket.id, user.company_id, user.id)));
+    const uploadedNames = files.filter((_, index) => !results[index].error).map((file) => file.name);
+    if (uploadedNames.length > 0) {
+      await addTicketComment(
+        ticket.id,
+        { message: `Attached ${uploadedNames.length} file${uploadedNames.length === 1 ? '' : 's'}.`, attachmentNames: uploadedNames },
+        { userId: user.id, companyId: user.company_id },
+      );
+    }
+    setSaving(false);
+    const failedCount = results.filter((result) => result.error).length;
+    if (failedCount > 0) toast.error(`${failedCount} attachment${failedCount === 1 ? '' : 's'} failed to upload.`);
+    await refreshWorkspace();
+  };
+
+  const handleAddInternalNote = async () => {
+    if (!ticket || !user || !internalNoteDraft.trim()) return;
+    const note = internalNoteDraft.trim();
+    const ok = await runWorkflow(
+      () => addTicketInternalNote(ticket.id, { note }, { userId: user.id, companyId: user.company_id }),
+      'Internal note added',
+    );
+    if (ok) setInternalNoteDraft('');
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[420px] items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error || !ticket || !data) {
+    return (
+      <div className="p-4 lg:p-6">
+        <HrmsEmptyState
+          icon={AlertCircle}
+          title="Unable to load request workspace"
+          description={(error as Error)?.message ?? 'The request could not be found or you do not have access.'}
+          action={{ label: 'Back to requests', onClick: () => navigate(getFallbackTicketListPath(canManageQueue)) }}
+        />
+      </div>
+    );
+  }
+
+  const primaryLabel = primaryActionLabel(ticket, data.permissions);
+
+  return (
+    <div className="min-h-full bg-muted/20">
+      <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-4 p-3 sm:p-4 lg:p-6">
+        <header className="sticky top-0 z-20 rounded-lg border border-border bg-background/95 p-4 shadow-sm backdrop-blur">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0 space-y-2">
+              <Button type="button" variant="ghost" size="sm" className="h-9 gap-1.5 px-2" onClick={handleBack}>
+                <ArrowLeft className="h-4 w-4" />
+                Back to previous view
+              </Button>
+              <div className="space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-xs font-semibold uppercase text-muted-foreground">{ticket.id}</span>
+                  <RequestStatusBadge status={ticket.status} />
+                  <TicketSlaSummary ticket={ticket} compact />
+                  <RequestPriorityBadge priority={ticket.priority} />
+                </div>
+                <h1 className="break-words text-xl font-semibold leading-7 text-foreground lg:text-2xl">{ticket.subject}</h1>
+                <p className="text-sm text-muted-foreground">
+                  {ticket.submitted_by_name ?? ticket.submitted_by_email ?? 'Unknown requester'}
+                  {ticket.vso_number ? ` · VSO ${ticket.vso_number}` : ''}
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+              <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">Submitted</span> {formatDateTime(ticket.created_at)}
+              </div>
+              <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">Updated</span> {formatDateTime(ticket.updated_at)}
+              </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button type="button" variant="outline" size="icon" className="h-10 w-10" aria-label="More request actions">
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {data.permissions.canManageWorkflow && (
+                    <>
+                      <DropdownMenuItem onClick={() => setAssignOpen(true)}>Assign owner</DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => setPriorityOpen(true)}>Change priority</DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => setOverrideOpen(true)}>Admin override status</DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                    </>
+                  )}
+                  {data.permissions.canViewAuditTrail && <DropdownMenuItem onClick={() => setTab('audit-trail')}>View audit trail</DropdownMenuItem>}
+                  <DropdownMenuItem onClick={() => void refreshWorkspace()}>Refresh workspace</DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+        </header>
+
+        {needsBreachReason && (
+          <div className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200">
+            <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>
+              <p className="font-semibold">SLA breach reason required</p>
+              <p className="mt-0.5">Add the breach reason in the completion workflow before this request can be completed or closed.</p>
+            </div>
+          </div>
+        )}
+
+        <div className="sticky top-[96px] z-10 rounded-lg border border-border bg-background/95 p-3 shadow-sm backdrop-blur">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="grid gap-2 text-sm md:grid-cols-3 lg:flex lg:flex-wrap">
+              <InfoRow label="Responsible party" value={ticket.current_responsible_party} />
+              <InfoRow label="Next action" value={ticket.next_action} />
+              <InfoRow label="SLA status" value={sla ? formatTicketLabel(sla.overall) : 'Not configured'} />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {data.permissions.canReviewApproval && (
+                <>
+                  <Button type="button" variant="outline" className="gap-1.5" onClick={() => setReviewDecision('approved')} disabled={saving}>
+                    <CheckCircle2 className="h-4 w-4" />
+                    Approve
+                  </Button>
+                  <Button type="button" variant="outline" className="gap-1.5 border-red-300 text-red-700 hover:bg-red-50 hover:text-red-800" onClick={() => setReviewDecision('rejected')} disabled={saving}>
+                    Reject
+                  </Button>
+                </>
+              )}
+              {data.permissions.canManageWorkflow && (
+                <Button type="button" variant="outline" onClick={() => setInfoDialogOpen(true)} disabled={saving || ticket.status === 'closed' || ticket.status === 'cancelled'}>
+                  Request More Info
+                </Button>
+              )}
+              {primaryLabel && (
+                <Button type="button" onClick={() => void handlePrimaryAction()} disabled={saving}>
+                  {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  {primaryLabel}
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <main className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="min-w-0 space-y-4">
+            <Tabs value={activeTab} onValueChange={setTab} className="space-y-4">
+              <div className="overflow-x-auto">
+                <TabsList className="h-auto min-w-max justify-start">
+                  {visibleTabs.map((tab) => (
+                    <TabsTrigger key={tab.value} value={tab.value} className="min-h-9">
+                      {tab.label}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+              </div>
+
+              <TabsContent value="overview" className="space-y-4">
+                <div className="grid gap-3 md:grid-cols-3">
+                  <InfoRow label="Current responsible party" value={ticket.current_responsible_party} />
+                  <InfoRow label="Owner / PIC" value={ticket.assigned_to_name ?? ticket.responsible_queue} />
+                  <InfoRow label="Next action" value={ticket.next_action} />
+                </div>
+                <Section title="Request summary" icon={FileText}>
+                  <p className="whitespace-pre-line text-sm leading-6 text-foreground">{ticket.description}</p>
+                </Section>
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <Section title="Latest discussion" icon={MessageSquare}>
+                    {latestChatMessage ? (
+                      <div className="rounded-md bg-muted/30 px-3 py-2">
+                        <p className="text-sm text-foreground">{latestChatMessage.message}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {latestChatMessage.actor_name ?? 'User'} · {latestChatMessage.created_at ? formatDistanceToNow(new Date(latestChatMessage.created_at), { addSuffix: true }) : ''}
+                        </p>
+                      </div>
+                    ) : <EmptyPanel title="No chat yet" description="Conversation with the requester will appear here." />}
+                  </Section>
+                  <Section title="Latest activity" icon={Clock3}>
+                    {latestSystemActivity ? (
+                      <div className="rounded-md bg-muted/30 px-3 py-2">
+                        <p className="text-sm text-foreground">{latestSystemActivity.message}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {latestSystemActivity.actor_name ?? 'System'} · {latestSystemActivity.created_at ? formatDistanceToNow(new Date(latestSystemActivity.created_at), { addSuffix: true }) : ''}
+                        </p>
+                      </div>
+                    ) : <EmptyPanel title="No activity yet" description="System workflow events will appear here." />}
+                  </Section>
+                </div>
+                <Section title="Resolution status">
+                  <div className="grid gap-3 md:grid-cols-3">
+                    <InfoRow label="Resolution note" value={ticket.resolution_note ?? 'Not completed'} />
+                    <InfoRow label="Completion category" value={ticket.completion_category ? formatTicketLabel(ticket.completion_category) : 'Not selected'} />
+                    <InfoRow label="Closure confirmed" value={ticket.closure_confirmed ? 'Yes' : 'No'} />
+                  </div>
+                </Section>
+              </TabsContent>
+
+              <TabsContent value="details" className="space-y-4">
+                <Section title="Request details">
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <InfoRow label="Category" value={getRequestCategoryLabel(ticket.category, categories)} />
+                    <InfoRow label="Subcategory" value={ticket.subcategory ? getRequestSubcategoryLabel(ticket.subcategory, ticket.category, subcategories) : 'Not selected'} />
+                    <InfoRow label="Requested due date" value={ticket.requested_due_date ? formatDueDate(ticket.requested_due_date) : 'Not provided'} />
+                    <InfoRow label="VSO" value={ticket.vso_number ?? 'Not provided'} />
+                    <InfoRow label="Desired outcome" value={ticket.desired_outcome ?? 'Not provided'} />
+                    <InfoRow label="Business impact" value={ticket.business_impact ?? 'Not provided'} />
+                  </div>
+                </Section>
+                {customFields.length > 0 && (
+                  <Section title="Additional fields">
+                    <div className="grid gap-3 md:grid-cols-2">
+                      {customFields.map((field) => (
+                        <InfoRow key={field.key} label={field.label} value={field.value} />
+                      ))}
+                    </div>
+                  </Section>
+                )}
+              </TabsContent>
+
+              <TabsContent value="chat">
+                <TicketChatPanel
+                  activities={data.activities}
+                  currentUserId={user?.id}
+                  draft={commentDraft}
+                  saving={saving}
+                  onDraftChange={setCommentDraft}
+                  onSend={() => void handleAddComment()}
+                  onAttachFiles={(files) => void handleChatFilesSelected(files)}
+                />
+              </TabsContent>
+
+              <TabsContent value="attachments">
+                {data.attachments.length > 0
+                  ? <TicketAttachmentList attachments={data.attachments} />
+                  : <EmptyPanel title="No attachments" description="Uploaded documents and images will appear here." />}
+              </TabsContent>
+
+              <TabsContent value="resolution" className="space-y-4">
+                <Section title="Resolution workflow">
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <InfoRow label="Resolution summary" value={ticket.resolution_note ?? 'Not completed'} />
+                    <InfoRow label="Completion category" value={ticket.completion_category ? formatTicketLabel(ticket.completion_category) : 'Not selected'} />
+                    <InfoRow label="SLA breach reason" value={ticket.sla_breach_reason ?? 'Not required or not entered'} />
+                    <InfoRow label="Completed at" value={formatDateTime(ticket.resolved_at)} />
+                  </div>
+                  {data.permissions.canManageWorkflow && ticket.status !== 'closed' && ticket.status !== 'cancelled' && (
+                    <Button type="button" className="mt-4" onClick={() => setCompletionOpen(true)}>
+                      Mark as Completed
+                    </Button>
+                  )}
+                </Section>
+              </TabsContent>
+
+              {data.permissions.canViewInternalNotes && (
+                <TabsContent value="internal-notes">
+                  <TicketInternalNotesPanel
+                    notes={data.internalNotes}
+                    draft={internalNoteDraft}
+                    saving={saving}
+                    onDraftChange={setInternalNoteDraft}
+                    onSend={() => void handleAddInternalNote()}
+                  />
+                </TabsContent>
+              )}
+
+              <TabsContent value="activity">
+                {data.activities.some((activity) => activity.event_type !== 'comment_added')
+                  ? <TicketActivityList activities={data.activities} />
+                  : <EmptyPanel title="No activity yet" description="System-generated workflow events will appear here." />}
+              </TabsContent>
+
+              {data.permissions.canViewAuditTrail && (
+                <TabsContent value="audit-trail">
+                  <AuditTrailPanel entries={data.auditEntries} activities={data.activities} />
+                </TabsContent>
+              )}
+            </Tabs>
+          </div>
+
+          <aside className="space-y-4 xl:sticky xl:top-[180px] xl:self-start">
+            <Section title="Insight panel" icon={UserRound}>
+              <div className="space-y-2">
+                <InfoRow label="Requester" value={ticket.submitted_by_name ?? ticket.submitted_by_email ?? 'Unknown'} />
+                <InfoRow label="Owner / PIC" value={ticket.assigned_to_name ?? ticket.responsible_queue} />
+                <InfoRow label="Backup owner" value={ticket.backup_owner_name ?? 'Not assigned'} />
+                <InfoRow label="Escalation owner" value={ticket.escalation_owner_name ?? 'Not assigned'} />
+                <InfoRow label="Last action by" value={ticket.last_action_by_name ?? 'System'} />
+              </div>
+            </Section>
+            <TicketSlaSummary ticket={ticket} />
+            <TicketOperationalIndicatorGrid indicator={data.operationalIndicator} />
+            <Section title="Accountability">
+              <div className="space-y-2">
+                <InfoRow label="Time in current status" value={formatDistanceToNow(new Date(ticket.status_changed_at), { addSuffix: false })} />
+                <InfoRow label="Request age" value={formatDistanceToNow(new Date(ticket.created_at), { addSuffix: false })} />
+                <InfoRow label="Chat messages" value={String(data.chatSummary.message_count)} />
+                <InfoRow label="Unread messages" value={String(data.chatSummary.unread_count)} />
+              </div>
+            </Section>
+          </aside>
+        </main>
+      </div>
+
+      <MessageDialog
+        open={infoDialogOpen}
+        title="Request more information"
+        description="This moves the request to Pending Requester and records the message in chat."
+        value={workflowMessage}
+        onValueChange={setWorkflowMessage}
+        saving={saving}
+        onOpenChange={(open) => { setInfoDialogOpen(open); if (!open) setWorkflowMessage(''); }}
+        onSubmit={async () => {
+          if (!user || !workflowMessage.trim()) return;
+          const ok = await runWorkflow(
+            () => requestTicketMoreInformation(ticket.id, { message: workflowMessage.trim() }, { userId: user.id, companyId: user.company_id }),
+            'Information requested',
+          );
+          if (ok) {
+            setWorkflowMessage('');
+            setInfoDialogOpen(false);
+          }
+        }}
+      />
+
+      <MessageDialog
+        open={requesterUpdateOpen}
+        title="Submit update"
+        description="This moves the request to Pending Owner Review."
+        value={workflowMessage}
+        onValueChange={setWorkflowMessage}
+        saving={saving}
+        onOpenChange={(open) => { setRequesterUpdateOpen(open); if (!open) setWorkflowMessage(''); }}
+        onSubmit={async () => {
+          if (!user || !workflowMessage.trim()) return;
+          const ok = await runWorkflow(
+            () => submitRequesterTicketUpdate(ticket.id, { message: workflowMessage.trim() }, { userId: user.id, companyId: user.company_id }),
+            'Update submitted',
+          );
+          if (ok) {
+            setWorkflowMessage('');
+            setRequesterUpdateOpen(false);
+          }
+        }}
+      />
+
+      <Dialog open={completionOpen} onOpenChange={(open) => { setCompletionOpen(open); if (!open) setCompletionChecklistConfirmed(false); }}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Mark request completed</DialogTitle>
+            <DialogDescription>Completion is auditable and visible to the requester before final closure.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="resolution-summary">Resolution summary</Label>
+              <Textarea id="resolution-summary" value={resolutionSummary} onChange={(event) => setResolutionSummary(event.target.value)} rows={4} />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Completion category</Label>
+              <Select value={completionCategory} onValueChange={(value) => setCompletionCategory(value as TicketCompletionCategory)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="resolved">Resolved</SelectItem>
+                  <SelectItem value="rejected">Rejected</SelectItem>
+                  <SelectItem value="duplicate">Duplicate</SelectItem>
+                  <SelectItem value="cancelled">Cancelled</SelectItem>
+                  <SelectItem value="not_applicable">Not Applicable</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {needsBreachReason && (
+              <div className="space-y-1.5">
+                <Label htmlFor="breach-reason">Breach reason</Label>
+                <Textarea id="breach-reason" value={completionBreachReason} onChange={(event) => setCompletionBreachReason(event.target.value)} rows={3} />
+              </div>
+            )}
+            <label htmlFor="completion-checklist" className="flex items-start gap-2 rounded-md border border-border px-3 py-2 text-sm">
+              <Checkbox id="completion-checklist" checked={completionChecklistConfirmed} onCheckedChange={(checked) => setCompletionChecklistConfirmed(Boolean(checked))} />
+              <span>Resolution, category, attachments, and breach reason are complete where required.</span>
+            </label>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => setCompletionOpen(false)}>Cancel</Button>
+            <Button
+              type="button"
+              disabled={saving || !resolutionSummary.trim() || !completionChecklistConfirmed || (needsBreachReason && !completionBreachReason.trim())}
+              onClick={async () => {
+                if (!user) return;
+                const ok = await runWorkflow(
+                  () => markTicketCompletedByOwner(
+                    ticket.id,
+                    {
+                      resolutionNote: resolutionSummary,
+                      completionCategory,
+                      checklistConfirmed: completionChecklistConfirmed,
+                      slaBreachReason: completionBreachReason,
+                    },
+                    { userId: user.id, companyId: user.company_id },
+                  ),
+                  'Request marked completed',
+                );
+                if (ok) setCompletionOpen(false);
+              }}
+            >
+              Mark completed
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={closeOpen} onOpenChange={setCloseOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Close request</DialogTitle>
+            <DialogDescription>Confirm the owner resolution and optionally rate the experience.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <label htmlFor="close-confirmed" className="flex items-start gap-2 rounded-md border border-border px-3 py-2 text-sm">
+              <Checkbox id="close-confirmed" checked={closeConfirmed} onCheckedChange={(checked) => setCloseConfirmed(Boolean(checked))} />
+              <span>I confirm this request is resolved.</span>
+            </label>
+            <div className="space-y-1.5">
+              <Label>Satisfaction rating</Label>
+              <Select value={satisfactionRating} onValueChange={setSatisfactionRating}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {[5, 4, 3, 2, 1].map((rating) => <SelectItem key={rating} value={String(rating)}>{rating}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            <Textarea value={closureFeedback} onChange={(event) => setClosureFeedback(event.target.value)} rows={3} placeholder="Optional feedback" />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => setCloseOpen(false)}>Cancel</Button>
+            <Button
+              type="button"
+              disabled={saving || !closeConfirmed}
+              onClick={async () => {
+                if (!user) return;
+                const ok = await runWorkflow(
+                  () => closeTicketByRequester(
+                    ticket.id,
+                    { confirmedResolved: closeConfirmed, satisfactionRating: Number(satisfactionRating), feedbackComment: closureFeedback },
+                    { userId: user.id, companyId: user.company_id },
+                  ),
+                  'Request closed',
+                );
+                if (ok) setCloseOpen(false);
+              }}
+            >
+              Close request
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <MessageDialog
+        open={reopenOpen}
+        title="Reopen request"
+        description="Provide the reason so the owner understands what needs attention."
+        value={reopenReason}
+        onValueChange={setReopenReason}
+        saving={saving}
+        onOpenChange={(open) => { setReopenOpen(open); if (!open) setReopenReason(''); }}
+        onSubmit={async () => {
+          if (!user || !reopenReason.trim()) return;
+          const ok = await runWorkflow(
+            () => reopenTicketByRequester(ticket.id, { reason: reopenReason }, { userId: user.id, companyId: user.company_id }),
+            'Request reopened',
+          );
+          if (ok) {
+            setReopenReason('');
+            setReopenOpen(false);
+          }
+        }}
+      />
+
+      <Dialog open={assignOpen} onOpenChange={setAssignOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Assign owner</DialogTitle>
+            <DialogDescription>Owner changes are recorded in the request activity trail.</DialogDescription>
+          </DialogHeader>
+          <Select value={selectedAssignee} onValueChange={setSelectedAssignee}>
+            <SelectTrigger><SelectValue placeholder="Assign owner" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="unassigned">Unassigned</SelectItem>
+              {data.assignees.map((assignee) => (
+                <SelectItem key={assignee.id} value={assignee.id}>{assignee.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => setAssignOpen(false)}>Cancel</Button>
+            <Button
+              type="button"
+              disabled={saving}
+              onClick={async () => {
+                if (!user) return;
+                const ok = await runWorkflow(
+                  () => updateTicket(ticket.id, { assigned_to: selectedAssignee === 'unassigned' ? null : selectedAssignee }, { userId: user.id, companyId: user.company_id }),
+                  'Owner updated',
+                );
+                if (ok) setAssignOpen(false);
+              }}
+            >
+              Save owner
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={priorityOpen} onOpenChange={setPriorityOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Change priority</DialogTitle>
+            <DialogDescription>Priority changes are visible to operators and requesters.</DialogDescription>
+          </DialogHeader>
+          <Select value={selectedPriority} onValueChange={(value) => setSelectedPriority(value as TicketPriority)}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {priorityOptions.map((option) => <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => setPriorityOpen(false)}>Cancel</Button>
+            <Button
+              type="button"
+              disabled={saving}
+              onClick={async () => {
+                if (!user) return;
+                const ok = await runWorkflow(
+                  () => updateTicket(ticket.id, { priority: selectedPriority }, { userId: user.id, companyId: user.company_id }),
+                  'Priority updated',
+                );
+                if (ok) setPriorityOpen(false);
+              }}
+            >
+              Save priority
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={overrideOpen} onOpenChange={(open) => { setOverrideOpen(open); if (!open) setOverrideReason(''); }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Admin override status</DialogTitle>
+            <DialogDescription>Manual status changes require a reason and are recorded in the audit trail.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Select value={overrideStatus} onValueChange={(value) => setOverrideStatus(value as TicketStatus)}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {statusOptions.map((option) => <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>)}
+              </SelectContent>
+            </Select>
+            <Textarea value={overrideReason} onChange={(event) => setOverrideReason(event.target.value)} rows={3} placeholder="Required reason" />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => setOverrideOpen(false)}>Cancel</Button>
+            <Button
+              type="button"
+              disabled={saving || !overrideReason.trim()}
+              onClick={async () => {
+                if (!user) return;
+                const ok = await runWorkflow(
+                  () => updateTicket(ticket.id, { status: overrideStatus, admin_override_reason: overrideReason }, { userId: user.id, companyId: user.company_id }),
+                  'Status overridden',
+                );
+                if (ok) {
+                  setOverrideReason('');
+                  setOverrideOpen(false);
+                }
+              }}
+            >
+              Override status
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={reviewDecision !== null} onOpenChange={(open) => { if (!open) { setReviewDecision(null); setReviewNote(''); } }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{reviewDecision === 'approved' ? 'Approve request' : 'Reject request'}</DialogTitle>
+            <DialogDescription>{reviewDecision === 'approved' ? 'Record approval for the current step.' : 'Rejecting approval may stop the request workflow.'}</DialogDescription>
+          </DialogHeader>
+          <Textarea value={reviewNote} onChange={(event) => setReviewNote(event.target.value)} rows={3} placeholder="Optional note" />
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => setReviewDecision(null)}>Cancel</Button>
+            <Button
+              type="button"
+              disabled={saving || !reviewDecision}
+              onClick={async () => {
+                if (!user || !reviewDecision) return;
+                const decision = reviewDecision;
+                const ok = await runWorkflow(
+                  () => reviewInternalRequestApproval(ticket.id, decision, reviewNote, { userId: user.id, companyId: user.company_id })
+                    .then((result) => ({ error: result.error ? new Error(result.error) : null })),
+                  decision === 'approved' ? 'Approval recorded' : 'Rejection recorded',
+                );
+                if (ok) {
+                  setReviewDecision(null);
+                  setReviewNote('');
+                }
+              }}
+            >
+              {reviewDecision === 'approved' ? 'Approve' : 'Reject'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function MessageDialog({
+  open,
+  title,
+  description,
+  value,
+  saving,
+  onValueChange,
+  onOpenChange,
+  onSubmit,
+}: {
+  open: boolean;
+  title: string;
+  description: string;
+  value: string;
+  saving: boolean;
+  onValueChange: (value: string) => void;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <Textarea value={value} onChange={(event) => onValueChange(event.target.value)} rows={4} placeholder="Write a clear update" />
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button type="button" disabled={saving || !value.trim()} onClick={onSubmit}>
+            {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            Submit
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AuditTrailPanel({
+  entries,
+  activities,
+}: {
+  entries: TicketAuditEntryRecord[];
+  activities: TicketWorkspaceData['activities'];
+}) {
+  const systemActivities = activities.filter((activity) => activity.event_type !== 'comment_added');
+
+  if (entries.length === 0 && systemActivities.length === 0) {
+    return <EmptyPanel title="No audit trail yet" description="Auditable changes and workflow events will appear here." />;
+  }
+
+  return (
+    <div className="space-y-3">
+      {entries.length > 0 && (
+        <Section title="Audit log">
+          <div className="space-y-2">
+            {entries.map((entry) => (
+              <div key={entry.id} className="rounded-md border border-border bg-card px-3 py-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline" className="capitalize">{entry.action}</Badge>
+                  <p className="text-sm font-medium text-foreground">{entry.actor_name ?? 'User action'}</p>
+                  <p className="text-xs text-muted-foreground">{entry.created_at ? formatDateTime(entry.created_at) : ''}</p>
+                </div>
+                {entry.changes && Object.keys(entry.changes).length > 0 && (
+                  <pre className="mt-2 max-h-40 overflow-auto rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+                    {JSON.stringify(entry.changes, null, 2)}
+                  </pre>
+                )}
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+      {systemActivities.length > 0 && (
+        <Section title="Workflow activity">
+          <TicketActivityList activities={activities} />
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -247,6 +247,35 @@ export interface TicketInternalNoteRecord {
   updated_at: string;
 }
 
+export interface TicketAuditEntryRecord {
+  id: string;
+  user_id: string;
+  actor_name: string | null;
+  action: string;
+  entity_type: string | null;
+  entity_id: string | null;
+  table_name: string | null;
+  changes: Record<string, unknown> | null;
+  created_at: string | null;
+}
+
+export interface TicketWorkspacePermissions {
+  canManageWorkflow: boolean;
+  canCloseAsRequester: boolean;
+  canViewInternalNotes: boolean;
+  canViewAuditTrail: boolean;
+  canReviewApproval: boolean;
+}
+
+export interface TicketWorkspaceData {
+  ticket: CompanyTicketRecord;
+  activities: TicketActivityRecord[];
+  chatSummary: TicketChatSummary;
+  internalNotes: TicketInternalNoteRecord[];
+  auditEntries: TicketAuditEntryRecord[];
+  permissions: TicketWorkspacePermissions;
+}
+
 export interface DuplicateTicketCandidate {
   id: string;
   subject: string;
@@ -287,6 +316,17 @@ interface TicketActivityInsert extends TicketActivityDbInsert {
   event_type: TicketActivityEventType;
   message: string;
   metadata: Json;
+}
+
+interface TicketAuditRow {
+  id: string;
+  user_id: string;
+  action: string;
+  entity_type: string | null;
+  entity_id: string | null;
+  table_name: string | null;
+  changes: Record<string, unknown> | null;
+  created_at: string | null;
 }
 
 const TICKET_SELECT =
@@ -878,6 +918,88 @@ export async function listCompanyTicketsPage(
   }
 }
 
+async function getCompanyTicketById(ticketId: string, companyId: string): Promise<CompanyTicketRecord | null> {
+  const { data, error } = await ticketsTable()
+    .select(TICKET_SELECT)
+    .eq('company_id', companyId)
+    .eq('id', ticketId)
+    .single();
+  if (error) throw error;
+  const [ticket] = await enrichCompanyTickets([mapTicket(data as unknown as TicketRow)], companyId);
+  return ticket ?? null;
+}
+
+function canReviewTicketApproval(
+  ticket: CompanyTicketRecord,
+  user: { id: string; role?: string | null },
+) {
+  if (ticket.approval_status !== 'pending') return false;
+  if (ticket.current_approver_user_id) return ticket.current_approver_user_id === user.id;
+  if (ticket.current_approver_role) return user.role === 'super_admin' || user.role === 'company_admin';
+  return false;
+}
+
+export async function getTicketWorkspaceData(
+  ticketId: string,
+  context: { userId: string; companyId: string; userRole?: string | null; canManagePortalQueue?: boolean },
+): Promise<TicketServiceResult<TicketWorkspaceData>> {
+  try {
+    const ticket = await getCompanyTicketById(ticketId, context.companyId);
+    if (!ticket) return { data: null, error: new Error('Request not found.') };
+
+    const canManagePortalQueue = Boolean(context.canManagePortalQueue);
+    const isRequester = ticket.submitted_by === context.userId;
+    if (!isRequester && !canManagePortalQueue) {
+      return { data: null, error: new Error('You do not have access to this request.') };
+    }
+
+    const permissions: TicketWorkspacePermissions = {
+      canManageWorkflow: canManagePortalQueue && !isRequester,
+      canCloseAsRequester: isRequester,
+      canViewInternalNotes: canManagePortalQueue,
+      canViewAuditTrail: canManagePortalQueue,
+      canReviewApproval: canReviewTicketApproval(ticket, { id: context.userId, role: context.userRole }),
+    };
+
+    const [{ data: activitiesByTicket }, { data: chatSummariesByTicket }, internalNoteResult, auditResult] = await Promise.all([
+      listTicketActivity([ticket.id], context.companyId),
+      listTicketChatSummaries([ticket.id], context.userId, context.companyId),
+      permissions.canViewInternalNotes
+        ? listTicketInternalNotes([ticket.id], context.companyId)
+        : Promise.resolve({ data: { [ticket.id]: [] as TicketInternalNoteRecord[] }, error: null }),
+      permissions.canViewAuditTrail
+        ? listTicketAuditEntries(ticket.id, context.companyId)
+        : Promise.resolve({ data: [] as TicketAuditEntryRecord[], error: null }),
+    ]);
+
+    if (internalNoteResult.error) throw internalNoteResult.error;
+    if (auditResult.error) throw auditResult.error;
+
+    const fallbackChatSummary: TicketChatSummary = {
+      ticket_id: ticket.id,
+      message_count: 0,
+      unread_count: 0,
+      latest_message_at: null,
+    };
+
+    return {
+      data: {
+        ticket,
+        activities: activitiesByTicket?.[ticket.id] ?? [],
+        chatSummary: chatSummariesByTicket?.[ticket.id] ?? fallbackChatSummary,
+        internalNotes: internalNoteResult.data?.[ticket.id] ?? [],
+        auditEntries: auditResult.data ?? [],
+        permissions,
+      },
+      error: null,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error('Failed to load request workspace');
+    loggingService.error('Failed to load request workspace', { error: error.message, ticketId }, 'TicketService');
+    return { data: null, error };
+  }
+}
+
 export interface TicketStatusCounts {
   all: number;
   open: number;
@@ -1102,6 +1224,42 @@ export async function listTicketInternalNotes(
   } catch (err) {
     const error = err instanceof Error ? err : new Error('Failed to load internal notes');
     loggingService.error('Failed to load internal notes', { error: error.message }, 'TicketService');
+    return { data: null, error };
+  }
+}
+
+export async function listTicketAuditEntries(
+  ticketId: string,
+  companyId: string,
+): Promise<TicketServiceResult<TicketAuditEntryRecord[]>> {
+  try {
+    const { data, error } = await table('audit_logs')
+      .select('id, user_id, action, entity_type, entity_id, table_name, changes, created_at')
+      .eq('entity_id', ticketId)
+      .or('entity_type.eq.ticket,entity_type.eq.internal_request,table_name.eq.tickets,table_name.eq.user_actions')
+      .order('created_at', { ascending: false })
+      .limit(100);
+    if (error) throw error;
+
+    const rows = (data ?? []) as TicketAuditRow[];
+    const profilesById = await fetchProfilesById(companyId, rows.map((row) => row.user_id));
+    return {
+      data: rows.map((row) => ({
+        id: row.id,
+        user_id: row.user_id,
+        actor_name: profilesById.get(row.user_id)?.name ?? null,
+        action: row.action,
+        entity_type: row.entity_type,
+        entity_id: row.entity_id,
+        table_name: row.table_name,
+        changes: row.changes,
+        created_at: row.created_at,
+      })),
+      error: null,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error('Failed to load request audit trail');
+    loggingService.error('Failed to load request audit trail', { error: error.message, ticketId }, 'TicketService');
     return { data: null, error };
   }
 }


### PR DESCRIPTION
## Summary

- add the canonical /portal/tickets/:ticketId ticket workspace route
- replace primary ticket list drawer handling with workspace navigation and chat deep links
- add a workspace service fetch path with role-aware internal notes, audit trail, chat, activity, and permission flags
- preserve setup/admin edit drawers and keep requester/new-request flows intact

## Impact

Requesters, owners, managers, and admins now open tickets in a full-page workspace with tabs, read-only default detail views, and intentional action dialogs. List pages retain their queue/list purpose and restore source state when returning from the workspace.

## Validation

- npm run lint
- npm run typecheck
- npm run build
- npm run test -- src/lib/ticketWorkspaceNavigation.test.ts src/services/ticketService.test.ts
- npx playwright test e2e/tickets.spec.ts e2e/internal-requests-runtime.spec.ts
